### PR TITLE
Changed the use of Name Variable

### DIFF
--- a/modules/azure/iam/main.tf
+++ b/modules/azure/iam/main.tf
@@ -22,7 +22,6 @@ resource "azurerm_role_assignment" "role_assignment" {
     "${role.object_id}_${role.role_name}${role.name != null ? "_${role.name}" : ""}" => role
   }
 
-  name                 = each.value.name
   scope                = each.value.scope
   role_definition_name = each.value.role_name
   principal_id         = each.value.object_id

--- a/modules/azure/iam/variables.tf
+++ b/modules/azure/iam/variables.tf
@@ -1,6 +1,6 @@
 variable "roles" {
   type = list(object({
-    name = optional(string), //unique UUID
+    name = optional(string), //unique Identifier
     object_id = string,
     role_name = string,
     scope     = string,


### PR DESCRIPTION
Changed the Use of name variable (now it is used solely for for-each to make distinction between array items. 
Name variable previously Created Complications with deployment on multiple Environments ( it is optional uuid and would anyway be created by azure)