### PR TITLE
add option to disable flow on deploy

### DIFF
--- a/modules/azure/logic_app/main.tf
+++ b/modules/azure/logic_app/main.tf
@@ -24,6 +24,7 @@ resource "azurerm_logic_app_workflow" "workflow" {
   name                = var.logic_app_name
   location            = var.location
   resource_group_name = var.resource_group_name
+  enabled             = var.enabled
 
   dynamic "identity" {
     for_each = var.use_managed_identity ? [1] : []

--- a/modules/azure/logic_app/variables.tf
+++ b/modules/azure/logic_app/variables.tf
@@ -37,6 +37,12 @@ variable "log_retention_days" {
   default     = 30
 }
 
+variable "enabled" {
+  type        = bool
+  description = "If this workflow should be enabled by default or not, defaults to true"
+  default     = true
+}
+
 variable "use_managed_identity" {
   type        = bool
   description = "Use Managed Identity for this logic app"


### PR DESCRIPTION
Allows workflows to be deployed in the "Disabled"  state, the default for terraform if the 'enabled' param is left out is true. 