### PR TITLE
Updated modules using optional to 1.3

### DIFF
--- a/modules/azure/api_management_api/main.tf
+++ b/modules/azure/api_management_api/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=1.0.9"
+  required_version = ">=1.3.0"
 
   required_providers {
     azurerm = {
@@ -13,10 +13,6 @@ terraform {
   }
 
   backend "azurerm" {}
-
-  # Optional attributes and the defaults function are
-  # both experimental, so we must opt in to the experiment.
-  experiments = [module_variable_optional_attrs]
 }
 
 provider "azurerm" {

--- a/modules/azure/api_management_api_operation_policy/main.tf
+++ b/modules/azure/api_management_api_operation_policy/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=1.0.9"
+  required_version = ">=1.3.0"
 
   required_providers {
     azurerm = {
@@ -9,10 +9,6 @@ terraform {
   }
 
   backend "azurerm" {}
-
-  # Optional attributes and the defaults function are
-  # both experimental, so we must opt in to the experiment.
-  experiments = [module_variable_optional_attrs]
 }
 
 provider "azurerm" {

--- a/modules/azure/event_grid_topic_subscription/main.tf
+++ b/modules/azure/event_grid_topic_subscription/main.tf
@@ -1,16 +1,11 @@
 terraform {
-  required_version = ">=1.1.2"
+  required_version = ">=1.3.0"
 
   required_providers {
     azurerm = "=2.96.0"
   }
 
   backend "azurerm" {}
-
-  # Optional attributes and the defaults function are
-  # both experimental, so we must opt in to the experiment.
-  experiments = [module_variable_optional_attrs]
-
 }
 
 provider "azurerm" {

--- a/modules/azure/frontdoor_classic/main.tf
+++ b/modules/azure/frontdoor_classic/main.tf
@@ -1,15 +1,11 @@
 terraform {
-  required_version = ">=1.1.7"
+  required_version = ">=1.3.0"
 
   required_providers {
     azurerm = "=3.10.0"
   }
 
   backend "azurerm" {}
-
-  # Optional attributes and the defaults function are
-  # both experimental, so we must opt in to the experiment.
-  experiments = [module_variable_optional_attrs]
 }
 
 provider "azurerm" {

--- a/modules/azure/frontdoor_firewall_policy/main.tf
+++ b/modules/azure/frontdoor_firewall_policy/main.tf
@@ -1,15 +1,11 @@
 terraform {
-  required_version = ">=1.1.7"
+  required_version = ">=1.3.0"
 
   required_providers {
     azurerm = "=3.10.0"
   }
 
   backend "azurerm" {}
-
-  # Optional attributes and the defaults function are
-  # both experimental, so we must opt in to the experiment.
-  experiments = [module_variable_optional_attrs]
 }
 
 provider "azurerm" {

--- a/modules/azure/iam/main.tf
+++ b/modules/azure/iam/main.tf
@@ -1,15 +1,11 @@
 terraform {
-  required_version = ">=1.1.7"
+  required_version = ">=1.3.0"
 
   required_providers {
     azurerm = "=3.10.0"
   }
 
   backend "azurerm" {}
-
-  # Optional attributes and the defaults function are
-  # both experimental, so we must opt in to the experiment.
-  experiments = [module_variable_optional_attrs]
 }
 
 provider "azurerm" {

--- a/modules/azure/monitoring/main.tf
+++ b/modules/azure/monitoring/main.tf
@@ -1,15 +1,11 @@
 terraform {
-  required_version = ">=1.1.7"
+  required_version = ">=1.3.0"
 
   required_providers {
     azurerm = "=3.10.0"
   }
 
   backend "azurerm" {}
-
-  # Optional attributes and the defaults function are
-  # both experimental, so we must opt in to the experiment.
-  experiments = [module_variable_optional_attrs]
 }
 
 provider "azurerm" {

--- a/modules/azure/network_security_group/main.tf
+++ b/modules/azure/network_security_group/main.tf
@@ -1,13 +1,11 @@
 terraform {
-  required_version = ">=0.14.9"
+  required_version = ">=1.3.0"
 
   required_providers {
     azurerm = ">=2.24.0"
   }
 
   backend "azurerm" {}
-
-  experiments = [module_variable_optional_attrs]
 }
 
 provider "azurerm" {

--- a/modules/azure/service_bus_subscription/main.tf
+++ b/modules/azure/service_bus_subscription/main.tf
@@ -1,11 +1,9 @@
 terraform {
-  required_version = ">=1.1.2"
+  required_version = ">=1.3.0"
 
   required_providers {
     azurerm = "=2.96.0"
   }
-
-  experiments = [module_variable_optional_attrs]
   backend "azurerm" {}
 }
 

--- a/modules/azure/synapse_workspace/main.tf
+++ b/modules/azure/synapse_workspace/main.tf
@@ -1,15 +1,11 @@
 terraform {
-  required_version = ">=1.2.2"
+  required_version = ">=1.3.0"
 
   required_providers {
     azurerm = "=3.23.0"
   }
 
   backend "azurerm" {}
-
-  # Optional attributes and the defaults function are
-  # both experimental, so we must opt in to the experiment.
-  experiments = [module_variable_optional_attrs]
 }
 
 provider "azurerm" {

--- a/modules/cloudflare/dns_records/main.tf
+++ b/modules/cloudflare/dns_records/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=1.1.7"
+  required_version = ">=1.3.0"
 
   required_providers {
     azurerm = ">=3.6.0"
@@ -10,10 +10,6 @@ terraform {
   }
 
   backend "azurerm" {}
-
-  # Optional attributes and the defaults function are
-  # both experimental, so we must opt in to the experiment.
-  experiments = [module_variable_optional_attrs]
 }
 
 provider "cloudflare" {}


### PR DESCRIPTION
Terraform no longer supports the experimental optional_vars flag. Updated all modules using it to >= 1.3.0
documentation can be found [here(new location)](https://developer.hashicorp.com/terraform/language/expressions/type-constraints#optional-object-type-attributes) or  [here(old location)](https://www.terraform.io/language/expressions/type-constraints#optional-object-type-attributes)

**NOTE**
This also means that locally it is _REQUIRED_ to run >=1.3.0 version of the terraform CLI. 
Backend updates will result in terraform init failures which can be fixed by either running the -reconfigure or -migrate-state flags during init or by removing the download cache when deploying locally.
