### PR TITLE
Add support for standard-plan logic apps

### DIFF
--- a/modules/azure/logic_app_standard/main.tf
+++ b/modules/azure/logic_app_standard/main.tf
@@ -1,0 +1,94 @@
+terraform {
+  required_version = ">=1.1.2"
+
+  required_providers {
+    azurerm = "=3.25.0"
+    archive = {
+      source  = "hashicorp/archive"
+      version = "2.2.0"
+    }
+  }
+
+  backend "azurerm" {}
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "archive" {
+}
+
+resource "azurerm_logic_app_standard" "app" {
+  name                = var.logic_app_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  enabled             = var.enabled
+
+  dynamic "identity" {
+    for_each = var.use_managed_identity ? [1] : []
+    content {
+      type = "SystemAssigned"
+    }
+  }
+
+  site_config {
+    ftps_state                = "Disabled"
+    elastic_instance_minimum  = var.elastic_instance_minimum
+    pre_warmed_instance_count = var.pre_warmed_instance_count
+  }
+
+  app_settings = merge({
+    WEBSITE_NODE_DEFAULT_VERSION = "~14",
+    FUNCTIONS_WORKER_RUNTIME     = "node",
+  }, var.app_settings)
+
+  app_service_plan_id        = var.service_plan_id
+  storage_account_access_key = var.storage_account_access_key
+  storage_account_name       = var.storage_account_name
+}
+
+resource "azurerm_app_service_virtual_network_swift_connection" "vnet_integration" {
+  count          = var.integration_subnet_id == null ? 0 : 1
+  app_service_id = azurerm_logic_app_standard.app.id
+  subnet_id      = var.integration_subnet_id
+}
+
+# First, create a zip file containing the workflow
+data "archive_file" "workflow" {
+  type        = "zip"
+  source_dir  = var.workflows_source_path
+  output_path = "${path.module}/files/deploy.zip"
+}
+
+# After the logic app is created, start a deployment using the Azure CLI
+# It is not possible to use a ZIP-deployment from blob storage, as it can not be updated from the portal
+
+# The first step is to ensure that the logic apps extension is installed
+resource "null_resource" "install-extension" {
+  depends_on = [azurerm_logic_app_standard.app]
+
+  triggers = {
+    deploy = data.archive_file.workflow.output_sha
+  }
+
+  provisioner "local-exec" {
+    command = "az extension add --name logic"
+  }
+}
+
+# Fetch the subscription name
+data "azurerm_subscription" "current" {}
+
+# Then use the Azure CLI to start the deployment
+resource "null_resource" "deploy" {
+  depends_on = [null_resource.install-extension]
+
+  triggers = {
+    deploy = data.archive_file.workflow.output_sha
+  }
+
+  provisioner "local-exec" {
+    command = "az logicapp deployment source config-zip --name ${var.logic_app_name} --resource-group ${var.resource_group_name} --subscription ${data.azurerm_subscription.current.display_name} --src ${data.archive_file.workflow.output_path}"
+  }
+}

--- a/modules/azure/logic_app_standard/outputs.tf
+++ b/modules/azure/logic_app_standard/outputs.tf
@@ -1,0 +1,7 @@
+output "principal_id" {
+  value = var.use_managed_identity ? azurerm_logic_app_standard.app.identity[0].principal_id : null
+}
+
+output "name" {
+  value = azurerm_logic_app_standard.app.name
+}

--- a/modules/azure/logic_app_standard/variables.tf
+++ b/modules/azure/logic_app_standard/variables.tf
@@ -1,0 +1,71 @@
+variable "location" {
+  type        = string
+  description = "A datacenter location in Azure."
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group."
+}
+
+variable "logic_app_name" {
+  type        = string
+  description = "Specifies the name of the logic app."
+}
+
+variable "service_plan_id" {
+  type        = string
+  description = "The ID of the Service Plan to use for this Logic App."
+}
+
+variable "storage_account_name" {
+  type        = string
+  description = "The name of the storage account to connect to the logic app"
+}
+
+variable "storage_account_access_key" {
+  type        = string
+  description = "The access key of the storage account to connect to the logic app."
+}
+
+variable "enabled" {
+  type        = bool
+  description = "If this workflow should be enabled by default or not, defaults to true"
+  default     = true
+}
+
+variable "use_managed_identity" {
+  type        = bool
+  description = "Use Managed Identity for this logic app"
+  default     = false
+}
+
+variable "app_settings" {
+  type        = map(string)
+  description = "A map of key/value pairs to be used as application settings for the logic app."
+  default     = {}
+}
+
+variable "workflows_source_path" {
+  type        = string
+  description = "The path to the source code of all workflows."
+}
+
+variable "integration_subnet_id" {
+  type        = string
+  description = "The ID of the integration subnet to enable virtual network integration."
+  default     = null
+}
+
+variable "elastic_instance_minimum" {
+  type        = number
+  description = "Minimum amount of elastic instances."
+  default     = 1
+}
+
+variable "pre_warmed_instance_count" {
+  type        = number
+  description = "Amount of pre-warmed instances. Requires at least 1 for VNet-integration."
+  default     = 0
+}
+

--- a/modules/azure/logic_app_standard_connection/main.tf
+++ b/modules/azure/logic_app_standard_connection/main.tf
@@ -1,0 +1,50 @@
+terraform {
+  required_version = ">=1.1.2"
+
+  required_providers {
+    azurerm = "=3.25.0"
+    archive = {
+      source  = "hashicorp/archive"
+      version = "2.2.0"
+    }
+  }
+
+  backend "azurerm" {}
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  v1 = var.kind == "V1"
+}
+
+resource "azurerm_api_connection" "connection_v1" {
+  count = local.v1 ? 1 : 0
+
+  name                = var.connection_name
+  resource_group_name = var.resource_group_name
+  managed_api_id      = var.managed_api_id
+
+  parameter_values = var.parameter_values
+
+  # Ignore changes as these are secure values and therefore not returned
+  lifecycle {
+    ignore_changes = [parameter_values]
+  }
+}
+
+resource "azurerm_resource_group_template_deployment" "connection_v2" {
+  count = local.v1 ? 0 : 1
+
+  name                = "${var.connection_name}-deployment"
+  resource_group_name = var.resource_group_name
+  deployment_mode     = "Incremental"
+  template_content    = file("${path.module}/v2_deployment.json")
+  parameters_content = jsonencode({
+    connection_name = { value = var.connection_name }
+    api_id          = { value = var.managed_api_id }
+    parameters      = { value = var.parameter_values }
+  })
+}

--- a/modules/azure/logic_app_standard_connection/outputs.tf
+++ b/modules/azure/logic_app_standard_connection/outputs.tf
@@ -1,0 +1,15 @@
+output "connection_id" {
+  value = local.v1 ? azurerm_api_connection.connection_v1[0].id : jsondecode(azurerm_resource_group_template_deployment.connection_v2[0].output_content)["connection_id"]["value"]
+}
+
+output "connection_name" {
+  value = var.connection_name
+}
+
+output "api_id" {
+  value = var.managed_api_id
+}
+
+output "connection_runtime_url" {
+  value = local.v1 ? null : jsondecode(azurerm_resource_group_template_deployment.connection_v2[0].output_content)["connection_runtime_url"]["value"]
+}

--- a/modules/azure/logic_app_standard_connection/v2_deployment.json
+++ b/modules/azure/logic_app_standard_connection/v2_deployment.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "connection_name": {
+      "type": "String",
+      "defaultValue": ""
+    },
+    "api_id": {
+      "type": "String",
+      "defaultValue": ""
+    },
+    "parameters": {
+      "type": "Object",
+      "defaultValue": {}
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Web/connections",
+      "apiVersion": "2016-06-01",
+      "name": "[parameters('connection_name')]",
+      "location": "northeurope",
+      "kind": "V2",
+      "properties": {
+        "displayName": "[parameters('connection_name')]",
+        "customParameterValues": {},
+        "parameterValues": "[parameters('parameters')]",
+        "api": {
+          "name": "azureloganalyticsdatacollector",
+          "id": "[parameters('api_id')]",
+          "type": "Microsoft.Web/locations/managedApis"
+        },
+        "testLinks": []
+      }
+    }
+  ],
+  "outputs": {
+    "connection_id": {
+      "type": "String",
+      "value": "[resourceId('Microsoft.Web/connections', parameters('connection_name'))]"
+    },
+    "connection_runtime_url": {
+      "type": "String",
+      "value": "[reference(resourceId('Microsoft.Web/connections', parameters('connection_name'))).connectionRuntimeUrl]"
+    }
+  }
+}

--- a/modules/azure/logic_app_standard_connection/variables.tf
+++ b/modules/azure/logic_app_standard_connection/variables.tf
@@ -1,0 +1,25 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group."
+}
+
+variable "connection_name" {
+  type        = string
+  description = "Name of the connection."
+}
+
+variable "managed_api_id" {
+  type        = string
+  description = "The ID of the API to manage."
+}
+
+variable "parameter_values" {
+  type        = map(string)
+  description = "Set of parameter values for the API connection."
+}
+
+variable "kind" {
+  type        = string
+  description = "The kind of the api connection (either V1 or V2)."
+  default     = "V1"
+}

--- a/modules/azure/logic_app_standard_connection_access_policy/main.tf
+++ b/modules/azure/logic_app_standard_connection_access_policy/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">=1.1.2"
+
+  required_providers {
+    azurerm = "=3.25.0"
+    archive = {
+      source  = "hashicorp/archive"
+      version = "2.2.0"
+    }
+  }
+
+  backend "azurerm" {}
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group_template_deployment" "policy" {
+  name                = "${var.connection_name}-ap"
+  resource_group_name = var.resource_group_name
+  deployment_mode     = "Incremental"
+  template_content    = file("${path.module}/policy.json")
+  parameters_content = jsonencode({
+    connection_name = { value = var.connection_name }
+    principal_id    = { value = var.principal_id }
+  })
+}

--- a/modules/azure/logic_app_standard_connection_access_policy/policy.json
+++ b/modules/azure/logic_app_standard_connection_access_policy/policy.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "connection_name": {
+      "type": "String",
+      "defaultValue": ""
+    },
+    "principal_id": {
+      "type": "String",
+      "defaultValue": ""
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Web/connections/accessPolicies",
+      "apiVersion": "2016-06-01",
+      "name": "[concat(parameters('connection_name'), '/', parameters('principal_id'))]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [],
+      "properties": {
+        "principal": {
+          "type": "ActiveDirectory",
+          "identity": {
+            "objectId": "[parameters('principal_id')]",
+            "tenantId": "[subscription().tenantId]"
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/modules/azure/logic_app_standard_connection_access_policy/variables.tf
+++ b/modules/azure/logic_app_standard_connection_access_policy/variables.tf
@@ -1,0 +1,15 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group."
+}
+
+variable "connection_name" {
+  type        = string
+  description = "Name of the connection."
+}
+
+variable "principal_id" {
+  type        = string
+  description = "The ID of the principal."
+  default     = null
+}


### PR DESCRIPTION
Standard logic apps are completely different to consumption-based logic apps with respect to their architecture. This PR adds a hidden dependency to the Azure CLI, but the alternative would be to use ZIP's & blob's, making the logic app designer unusable.