### PR TITLE
Allow delivery properties to be set for eventgrid subscriptions

### DIFF
--- a/modules/azure/event_grid_topic_subscription/main.tf
+++ b/modules/azure/event_grid_topic_subscription/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">=1.3.0"
 
   required_providers {
-    azurerm = "=2.96.0"
+    azurerm = "=3.26.0"
   }
 
   backend "azurerm" {}
@@ -35,4 +35,13 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "subscription" {
     }
   }
   included_event_types = var.event_types
+  dynamic "delivery_property" {
+    for_each = var.delivery_properties
+
+    content {
+      header_name = delivery_property.value.header_name
+      type        = delivery_property.value.propertyType
+      value       = delivery_property.value.propertyValue
+    }
+  }
 }

--- a/modules/azure/event_grid_topic_subscription/variables.tf
+++ b/modules/azure/event_grid_topic_subscription/variables.tf
@@ -31,10 +31,19 @@ variable "subject_filter" {
     case_sensitive      = optional(bool)
   })
   description = "parameters for subject filtering"
-  default = null
+  default     = null
 }
 
 variable "event_types" {
-  type = list(string)
+  type        = list(string)
   description = "A list of applicable event types that need to be part of the event subscription."
+}
+
+variable "delivery_properties" {
+  type = list(object({
+    header_name   = string
+    propertyType  = string
+    propertyValue = string
+  }))
+  description = "parameters for delivery properties"
 }


### PR DESCRIPTION
Eventgrid properties are imported for additional routing options, e.g. correlation or sql filters on servicebus topics.

Example of usage:
![image](https://user-images.githubusercontent.com/106074602/195362177-724d781a-6253-4f0b-ba6d-3cc748fecba2.png)
