### PR TITLE
Support providing basic auth credentials directly

### DIFF
--- a/modules/azure/api_management_api/main.tf
+++ b/modules/azure/api_management_api/main.tf
@@ -150,7 +150,7 @@ resource "azurerm_api_management_api_policy" "api_policy" {
       </set-header>
     %{endif}
     %{if var.backend_type == "basic-auth"}
-    <authentication-basic username="${data.azurerm_key_vault_secret.username[0].value}" password="${data.azurerm_key_vault_secret.password[0].value}" />
+    <authentication-basic username="${var.basic_auth_settings.username != null ? var.basic_auth_settings.username : data.azurerm_key_vault_secret.username[0].value}" password="${var.basic_auth_settings.password != null ? var.basic_auth_settings.password : data.azurerm_key_vault_secret.password[0].value}" />
     %{endif}
     %{if var.backend_type == "body-auth"}
     <set-body>@{
@@ -202,13 +202,13 @@ XML
 ######################################################
 
 data "azurerm_key_vault_secret" "username" {
-  count        = var.backend_type == "basic-auth" ? 1 : 0
+  count        = var.backend_type == "basic-auth" && var.basic_auth_settings.username_secret != null ? 1 : 0
   name         = var.basic_auth_settings.username_secret
   key_vault_id = var.basic_auth_settings.key_vault_id
 }
 
 data "azurerm_key_vault_secret" "password" {
-  count        = var.backend_type == "basic-auth" ? 1 : 0
+  count        = var.backend_type == "basic-auth" && var.basic_auth_settings.password_secret != null ? 1 : 0
   name         = var.basic_auth_settings.password_secret
   key_vault_id = var.basic_auth_settings.key_vault_id
 }

--- a/modules/azure/api_management_api/variables.tf
+++ b/modules/azure/api_management_api/variables.tf
@@ -115,11 +115,13 @@ variable "backend_type" {
 
 variable "basic_auth_settings" {
   type = object({
-    key_vault_id    = string,
-    username_secret = string,
-    password_secret = string,
+    key_vault_id    = optional(string),
+    username_secret = optional(string),
+    password_secret = optional(string),
+    username        = optional(string),
+    password        = optional(string),
   })
-  description = "Settings to be used for basic auth"
+  description = "Settings to be used for basic auth, one can either use a key vault or provide the username and password directly using named values."
   default     = null
 }
 


### PR DESCRIPTION
In some cases, it is better to work with named values, as the current implementation loads them at build time rather than on runtime. This PR adds support for both.