### PR TITLE
Remove output key that can cause 20 min error to retrieve keys when deploying function apps

### DIFF
--- a/modules/azure/function_app_linux/main.tf
+++ b/modules/azure/function_app_linux/main.tf
@@ -45,17 +45,6 @@ resource "azurerm_linux_function_app" "function_app" {
   }
 }
 
-# Host keys
-
-data "azurerm_function_app_host_keys" "host_keys" {
-  name                = var.name
-  resource_group_name = var.resource_group_name
-
-  depends_on = [
-    azurerm_linux_function_app.function_app
-  ]
-}
-
 # VNet integration
 
 resource "azurerm_app_service_virtual_network_swift_connection" "vnet_integration" {

--- a/modules/azure/function_app_linux/outputs.tf
+++ b/modules/azure/function_app_linux/outputs.tf
@@ -5,8 +5,3 @@ output "name" {
 output "principal_id" {
   value = azurerm_linux_function_app.function_app.identity.0.principal_id
 }
-
-output "host_key_master" {
-  value     = data.azurerm_function_app_host_keys.host_keys.default_function_key
-  sensitive = true
-}

--- a/modules/azure/function_app_linux_managed_identity/outputs.tf
+++ b/modules/azure/function_app_linux_managed_identity/outputs.tf
@@ -5,8 +5,3 @@ output "name" {
 output "principal_id" {
   value = azurerm_linux_function_app.function_app.identity.0.principal_id
 }
-
-output "host_key_master" {
-  value     = data.azurerm_function_app_host_keys.host_keys.default_function_key
-  sensitive = true
-}


### PR DESCRIPTION
This is the issues it should solve
![image](https://user-images.githubusercontent.com/89966532/198312173-c01f8132-6765-43ef-947a-05bd7c96f99b.png)
