### PR TITLE
fix null error

### DIFF
--- a/modules/azure/api_management_api/main.tf
+++ b/modules/azure/api_management_api/main.tf
@@ -202,13 +202,13 @@ XML
 ######################################################
 
 data "azurerm_key_vault_secret" "username" {
-  count        = var.backend_type == "basic-auth" && var.basic_auth_settings.username_secret != null ? 1 : 0
+  count        = var.backend_type == "basic-auth" && (var.basic_auth_settings != null ? var.basic_auth_settings.username_secret != null : false) ? 1 : 0
   name         = var.basic_auth_settings.username_secret
   key_vault_id = var.basic_auth_settings.key_vault_id
 }
 
 data "azurerm_key_vault_secret" "password" {
-  count        = var.backend_type == "basic-auth" && var.basic_auth_settings.password_secret != null ? 1 : 0
+  count        = var.backend_type == "basic-auth" && (var.basic_auth_settings != null ? var.basic_auth_settings.password_secret != null : false) ? 1 : 0
   name         = var.basic_auth_settings.password_secret
   key_vault_id = var.basic_auth_settings.key_vault_id
 }


### PR DESCRIPTION
@bartwesselink basic-auth settings were giving errors due to the count check when not usingbasic auth at all (basic_auth_settings = null, but trying to get variable from them). This should fix the issue by checking if basic_auth_settings is not null first before checking if the secret is set.

Error in question:
╷
│ Error: Attempt to get attribute from null value
│
│   on main.tf line 181, in data "azurerm_key_vault_secret" "username":
│  181:   count        = var.backend_type == "basic-auth" && var.basic_auth_settings.username_secret != null ? 1 : 0
│     ├────────────────
│     │ var.basic_auth_settings is null
│
│ This value is null, so it does not have any attributes.
╵
╷
│ Error: Attempt to get attribute from null value
│
│   on main.tf line 187, in data "azurerm_key_vault_secret" "password":
│  187:   count        = var.backend_type == "basic-auth" && var.basic_auth_settings.password_secret != null ? 1 : 0
│     ├────────────────
│     │ var.basic_auth_settings is null
│
│ This value is null, so it does not have any attributes.
╵
