### PR TITLE
Added simple version of the api without jwt validation

### DIFF
--- a/modules/azure/api_management_api_simple/main.tf
+++ b/modules/azure/api_management_api_simple/main.tf
@@ -1,0 +1,226 @@
+terraform {
+  required_version = ">=1.3.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=3.6.0"
+    }
+  }
+
+  backend "azurerm" {}
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+}
+
+#######################################################
+##########                API                ##########
+#######################################################
+
+resource "azurerm_api_management_api" "api" {
+  name                  = lower(replace(var.api_settings.name, " ", "-"))
+  description           = var.api_settings.description
+  resource_group_name   = var.resource_group_name
+  api_management_name   = var.api_management_name
+  service_url           = var.api_settings.service_url
+  revision              = var.api_settings.revision
+  display_name          = var.api_settings.name
+  path                  = var.api_settings.basepath
+  protocols             = ["https"]
+  subscription_required = var.api_settings.subscription_required
+
+  soap_pass_through = var.soap_pass_through
+
+  import {
+    content_format = var.api_settings.openapi_file_path != null ? "openapi" : "wsdl"
+    content_value  = var.api_settings.openapi_file_path != null ? file(var.api_settings.openapi_file_path) : file(var.api_settings.wsdl_file_path)
+
+    dynamic "wsdl_selector" {
+      for_each = var.wsdl_selector != null ? [1] : []
+      content {
+        service_name  = var.wsdl_selector.service_name
+        endpoint_name = var.wsdl_selector.endpoint_name
+      }
+    }
+  }
+}
+
+######################################################
+###########         API Diagnostics        ###########
+######################################################
+
+resource "azurerm_api_management_api_diagnostic" "api_diagnostic" {
+  count = var.api_management_logger_id != null ? 1 : 0
+
+  identifier               = "applicationinsights"
+  resource_group_name      = var.resource_group_name
+  api_management_name      = var.api_management_name
+  api_name                 = azurerm_api_management_api.api.name
+  api_management_logger_id = var.api_management_logger_id
+
+  sampling_percentage       = var.api_diagnostic_settings.sampling_percentage
+  always_log_errors         = var.api_diagnostic_settings.always_log_errors
+  log_client_ip             = var.api_diagnostic_settings.log_client_ip
+  verbosity                 = var.api_diagnostic_settings.verbosity
+  http_correlation_protocol = var.api_diagnostic_settings.http_correlation_protocol
+
+  frontend_request {
+    body_bytes = 32
+    headers_to_log = [
+      "content-type",
+      "accept",
+      "origin",
+    ]
+  }
+
+  frontend_response {
+    body_bytes = 32
+    headers_to_log = [
+      "content-type",
+      "content-length",
+      "origin",
+    ]
+  }
+
+  backend_request {
+    body_bytes = 32
+    headers_to_log = [
+      "content-type",
+      "accept",
+      "origin",
+    ]
+  }
+
+  backend_response {
+    body_bytes = 32
+    headers_to_log = [
+      "content-type",
+      "content-length",
+      "origin",
+    ]
+  }
+}
+
+#######################################################
+##########            API Policy             ##########
+#######################################################
+
+resource "azurerm_api_management_api_policy" "api_policy" {
+  api_name            = azurerm_api_management_api.api.name
+  api_management_name = var.api_management_name
+  resource_group_name = var.resource_group_name
+
+  xml_content = <<XML
+<policies>
+  <inbound>
+  <base />
+    %{if var.backend_type == "managed-identity"}
+    <authentication-managed-identity resource="${var.managed_identity_resource}" output-token-variable-name="msi-access-token" ignore-error="false" />
+      <set-header name="Authorization" exists-action="override">
+        <value>@("Bearer " + (string)context.Variables["msi-access-token"])</value>
+      </set-header>
+    %{endif}
+    %{if var.backend_type == "basic-auth"}
+    <authentication-basic username="${var.basic_auth_settings.username != null ? var.basic_auth_settings.username : data.azurerm_key_vault_secret.username[0].value}" password="${var.basic_auth_settings.password != null ? var.basic_auth_settings.password : data.azurerm_key_vault_secret.password[0].value}" />
+    %{endif}
+    %{if var.backend_type == "body-auth"}
+    <set-body>@{
+        var body = context.Request.Body.As<JObject>();
+        %{if var.soap_body_key != null}
+        body["${var.soap_body_key}"]["${var.body_auth_settings.username_key}"] = "${data.azurerm_key_vault_secret.body_username[0].value}";
+        body["${var.soap_body_key}"]["${var.body_auth_settings.password_key}"] = "${data.azurerm_key_vault_secret.body_password[0].value}";
+        %{else}
+        body["${var.body_auth_settings.username_key}"] = "${data.azurerm_key_vault_secret.body_username[0].value}";
+        body["${var.body_auth_settings.password_key}"] = "${data.azurerm_key_vault_secret.body_password[0].value}";
+        %{endif}
+        return body.ToString();
+        }
+    </set-body>
+    %{endif}
+    %{if var.backend_type == "oauth"}
+    <send-request ignore-error="true" timeout="20" response-variable-name="bearerToken" mode="new">
+      <set-url>https://login.microsoftonline.com/${var.oauth_settings.tenant_id}/oauth2/v2.0/token</set-url>
+      <set-method>POST</set-method>
+      <set-header name="Content-Type" exists-action="override">
+        <value>application/x-www-form-urlencoded</value>
+      </set-header>
+      <set-body>@{
+        return "client_id=${var.oauth_settings.client_id}&scope=${var.oauth_settings.scope}&client_secret=${var.oauth_settings.client_secret}&grant_type=client_credentials";
+        }
+      </set-body>
+    </send-request>
+    <set-header name="Authorization" exists-action="override">
+      <value>@("Bearer " + (String)((IResponse)context.Variables["bearerToken"]).Body.As<JObject>()["access_token"])</value>
+    </set-header>
+    %{endif}
+    <set-header name="Ocp-Apim-Subscription-Key" exists-action="delete" />
+    %{if var.backend_type == "api-token"}
+    <set-header name= "Authorization" exists-action="override">
+      %{if var.api_token_settings.prefix != null}
+      <value>${var.api_token_settings.prefix} ${var.api_token_settings.token}</value>
+      %{else}
+      <value>${var.api_token_settings.token}</value>
+      %{endif}
+    </set-header>
+    %{endif}
+  </inbound>
+</policies>
+XML
+}
+
+######################################################
+##########        Basic-auth serets        ###########
+######################################################
+
+data "azurerm_key_vault_secret" "username" {
+  count        = var.backend_type == "basic-auth" && (var.basic_auth_settings != null ? var.basic_auth_settings.username_secret != null : false) ? 1 : 0
+  name         = var.basic_auth_settings.username_secret
+  key_vault_id = var.basic_auth_settings.key_vault_id
+}
+
+data "azurerm_key_vault_secret" "password" {
+  count        = var.backend_type == "basic-auth" && (var.basic_auth_settings != null ? var.basic_auth_settings.password_secret != null : false) ? 1 : 0
+  name         = var.basic_auth_settings.password_secret
+  key_vault_id = var.basic_auth_settings.key_vault_id
+}
+
+######################################################
+##########        Body-auth serets        ###########
+######################################################
+
+data "azurerm_key_vault_secret" "body_username" {
+  count        = var.backend_type == "body-auth" ? 1 : 0
+  name         = var.body_auth_settings.username_secret
+  key_vault_id = var.body_auth_settings.key_vault_id
+}
+
+data "azurerm_key_vault_secret" "body_password" {
+  count        = var.backend_type == "body-auth" ? 1 : 0
+  name         = var.body_auth_settings.password_secret
+  key_vault_id = var.body_auth_settings.key_vault_id
+}
+
+######################################################
+#############        API products        #############
+######################################################
+
+resource "azurerm_api_management_product" "product" {
+  product_id            = azurerm_api_management_api.api.name
+  api_management_name   = var.api_management_name
+  resource_group_name   = var.resource_group_name
+  display_name          = azurerm_api_management_api.api.display_name
+  subscription_required = true
+  published             = true
+}
+
+resource "azurerm_api_management_product_api" "product_api" {
+  api_name            = azurerm_api_management_api.api.name
+  product_id          = azurerm_api_management_product.product.product_id
+  api_management_name = var.api_management_name
+  resource_group_name = var.resource_group_name
+}

--- a/modules/azure/api_management_api_simple/outputs.tf
+++ b/modules/azure/api_management_api_simple/outputs.tf
@@ -1,0 +1,7 @@
+output "api_name" {
+  value = azurerm_api_management_api.api.name
+}
+
+output "api_management_api_diagnostic" {
+  value = (var.api_diagnostic_settings != null && var.api_management_logger_id != null) ? azurerm_api_management_api_diagnostic.api_diagnostic[0].id : null
+}

--- a/modules/azure/api_management_api_simple/variables.tf
+++ b/modules/azure/api_management_api_simple/variables.tf
@@ -69,7 +69,7 @@ variable "api_diagnostic_settings" {
 
 variable "backend_type" {
   type        = string
-  description = "The type of backend used by the api. Should be public, basic-auth, body-auth or managed-identity"
+  description = "The type of backend used by the api. Should be public, basic-auth, oauth, body-auth, api-token or managed-identity"
 
   validation {
     condition     = contains(["public", "basic-auth", "managed-identity", "body-auth", "oauth", "api-token"], var.backend_type)

--- a/modules/azure/api_management_api_simple/variables.tf
+++ b/modules/azure/api_management_api_simple/variables.tf
@@ -1,0 +1,140 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group."
+}
+
+variable "api_management_name" {
+  type        = string
+  description = "The name of the API management service."
+}
+
+variable "api_settings" {
+  type = object({
+    name                  = string,
+    description           = optional(string),
+    service_url           = string,
+    revision              = string,
+    basepath              = string,
+    subscription_required = string,
+    openapi_file_path     = optional(string),
+    wsdl_file_path        = optional(string)
+  })
+  description = "Settings to use for this API. Either Openapi or wsdl file path should be set."
+}
+
+variable "wsdl_selector" {
+  type = object({
+    service_name  = string,
+    endpoint_name = string
+  })
+  description = "A selector for the wsdl file when only part of the document should be used"
+  default     = null
+}
+
+variable "owners" {
+  type        = list(any)
+  description = "List of AAD object IDs to set as API management owners."
+  default     = []
+}
+
+variable "api_management_logger_id" {
+  type        = string
+  description = "The Id of the API management Logger"
+  default     = null
+}
+
+variable "api_diagnostic_settings" {
+  type = object({
+    sampling_percentage       = number,
+    always_log_errors         = bool,
+    log_client_ip             = bool,
+    verbosity                 = string, # possible values: verbose, information, error
+    http_correlation_protocol = string, # possible values: None, Legacy, W3C
+  })
+
+  description = "Settings for api diagnostics, If not needed just privide a null value, Will be created only if api_management_logger_id have beeen provided"
+
+  default = {
+    sampling_percentage       = 5.0,
+    always_log_errors         = true,
+    log_client_ip             = true,
+    verbosity                 = "verbose", # possible values: verbose, information, error
+    http_correlation_protocol = "W3C"
+  }
+}
+
+#######################################################
+##########      Authentication Settings      ##########
+#######################################################
+
+variable "backend_type" {
+  type        = string
+  description = "The type of backend used by the api. Should be public, basic-auth, body-auth or managed-identity"
+
+  validation {
+    condition     = contains(["public", "basic-auth", "managed-identity", "body-auth", "oauth", "api-token"], var.backend_type)
+    error_message = "Argument \"backend_type\" must be either \"public\", \"basic-auth\", \"body-auth\", \"oauth\" , \"api-token\" or \"managed-identity\"."
+  }
+}
+
+variable "basic_auth_settings" {
+  type = object({
+    key_vault_id    = optional(string),
+    username_secret = optional(string),
+    password_secret = optional(string),
+    username        = optional(string),
+    password        = optional(string),
+  })
+  description = "Settings to be used for basic auth, one can either use a key vault or provide the username and password directly using named values."
+  default     = null
+}
+
+variable "body_auth_settings" {
+  type = object({
+    key_vault_id    = string,
+    username_key    = string,
+    username_secret = string,
+    password_secret = string,
+    password_key    = string,
+  })
+  description = "Values used for body authentication"
+  default     = null
+}
+
+variable "soap_body_key" {
+  type        = string
+  description = "The key used to prepend a json object in the body: {key: {object}} to transform for SOAP api as REST"
+  default     = null
+}
+
+variable "soap_pass_through" {
+  type        = string
+  description = "defines wether soap api should be converted to REST API"
+  default     = false
+}
+
+variable "oauth_settings" {
+  type = object({
+    tenant_id     = string, // May contain value or APIM variable: {{var_name}}
+    scope         = string, // May contain value or APIM variable: {{var_name}}
+    client_id     = string, // May contain value or APIM variable: {{var_name}}
+    client_secret = string, // May contain value or APIM variable: {{var_name}}
+  })
+  description = "Values used for oAuth authentication to the back-end"
+  default     = null
+}
+
+variable "api_token_settings" {
+  type = object({
+    prefix = optional(string), // fe Bearer or ApiToken
+    token  = string            // Can be value or APIM named value: {{var_name}}
+  })
+  description = "Values for api-token authentication"
+  default     = null
+}
+
+variable "managed_identity_resource" {
+  type        = string
+  description = "The resource to validate the managed identity"
+  default     = null
+}

--- a/modules/azure/function_app_linux_managed_identity/main.tf
+++ b/modules/azure/function_app_linux_managed_identity/main.tf
@@ -47,7 +47,7 @@ resource "azurerm_linux_function_app" "function_app" {
     active_directory {
       client_id         = local.should_create_app ? azuread_application.application[0].application_id : var.managed_identity_provider.existing.client_id
       client_secret     = local.should_create_app ? azuread_application_password.password[0].value : var.managed_identity_provider.existing.client_secret
-      allowed_audiences = var.managed_identity_provider.allowed_clients
+      allowed_audiences = concat(var.managed_identity_provider.allowed_clients, var.managed_identity_provider.create.identifies_uris != null ? var.managed_identity_provider.create.identifies_uris : ["api://${var.managed_identity_provider.create.application_name}"])
     }
   }
 


### PR DESCRIPTION
Version of the apim_api module but without JWT validation and AAD applications. Can be used for routes that need to be called by external parties since JWT will not be an option in these cases.

Custom policy can (and should) be used to set a different frontfacing security measure. Backend validations are inherited from the AD version of this module. (oauth/basic auth etc)