### PR TITLE
Feature/11453 add certificate to apim

### DIFF
--- a/modules/azure/api_management_certificate/main.tf
+++ b/modules/azure/api_management_certificate/main.tf
@@ -26,4 +26,14 @@ resource "azurerm_api_management_certificate" "apim_certificate" {
   resource_group_name = var.resource_group_name
 
   key_vault_secret_id = var.keyvault_certificate_id
+  data                = filebase64(var.certificate_location)
+  password            = var.certificate_password
+  
+
+  lifecycle {
+    precondition {
+      condition     = (var.certificate_location != null && var.keyvault_certificate_id==null) || (var.certificate_location == null && var.keyvault_certificate_id!=null)
+      error_message = "Wrong Keyvault ID and Certificate location COmbination, one and only one the those should have value"
+    }
+  }
 }

--- a/modules/azure/api_management_certificate/main.tf
+++ b/modules/azure/api_management_certificate/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">=1.3.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=3.6.0"
+    }
+  }
+
+  backend "azurerm" {}
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+}
+
+
+
+resource "azurerm_api_management_certificate" "apim_certificate" {
+  name                = var.name
+  api_management_name = var.api_management_name
+  resource_group_name = var.resource_group_name
+
+  key_vault_secret_id = var.keyvault_certificate_id
+}

--- a/modules/azure/api_management_certificate/main.tf
+++ b/modules/azure/api_management_certificate/main.tf
@@ -26,9 +26,8 @@ resource "azurerm_api_management_certificate" "apim_certificate" {
   resource_group_name = var.resource_group_name
 
   key_vault_secret_id = var.keyvault_certificate_id
-  data                = filebase64(var.certificate_location)
+  data                = var.certificate_location != null? filebase64(var.certificate_location): null
   password            = var.certificate_password
-  
 
   lifecycle {
     precondition {

--- a/modules/azure/api_management_certificate/main.tf
+++ b/modules/azure/api_management_certificate/main.tf
@@ -18,8 +18,6 @@ provider "azurerm" {
 locals {
 }
 
-
-
 resource "azurerm_api_management_certificate" "apim_certificate" {
   name                = var.name
   api_management_name = var.api_management_name

--- a/modules/azure/api_management_certificate/main.tf
+++ b/modules/azure/api_management_certificate/main.tf
@@ -30,7 +30,7 @@ resource "azurerm_api_management_certificate" "apim_certificate" {
   lifecycle {
     precondition {
       condition     = (var.certificate_location != null && var.keyvault_certificate_id==null) || (var.certificate_location == null && var.keyvault_certificate_id!=null)
-      error_message = "Wrong Keyvault ID and Certificate location COmbination, one and only one the those should have value"
+      error_message = "Please, specify a Certificate KeyVault ID or Certificate file location"
     }
   }
 }

--- a/modules/azure/api_management_certificate/outputs.tf
+++ b/modules/azure/api_management_certificate/outputs.tf
@@ -1,0 +1,15 @@
+output "thumbprint" {
+  value =  azurerm_api_management_certificate.apim_certificate.thumbprint
+}
+
+output "id" {
+  value =  azurerm_api_management_certificate.apim_certificate.id
+}
+
+output "subject" {
+  value =  azurerm_api_management_certificate.apim_certificate.subject
+}
+
+output "expiration" {
+  value =  azurerm_api_management_certificate.apim_certificate.expiration
+}

--- a/modules/azure/api_management_certificate/outputs.tf
+++ b/modules/azure/api_management_certificate/outputs.tf
@@ -1,3 +1,7 @@
+output "name" {
+  value = var.name
+}
+
 output "thumbprint" {
   value =  azurerm_api_management_certificate.apim_certificate.thumbprint
 }

--- a/modules/azure/api_management_certificate/variables.tf
+++ b/modules/azure/api_management_certificate/variables.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  type        = string
+  description = "certificate name"
+}
+
+variable "api_management_name" {
+  type        = string
+  description = "The Name of API Manager Where to Add the certificate"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group name where the Api Management is located"
+}
+
+variable "keyvault_certificate_id" {
+  type =  string
+  description = "the id of the certificate file in a keyvault"
+}

--- a/modules/azure/api_management_certificate/variables.tf
+++ b/modules/azure/api_management_certificate/variables.tf
@@ -16,4 +16,18 @@ variable "resource_group_name" {
 variable "keyvault_certificate_id" {
   type =  string
   description = "the id of the certificate file in a keyvault"
+  default = null
+}
+
+variable "certificate_location" {
+  type = string
+  description = "location of client certificate"
+  default = null
+}
+
+variable "certificate_password" {
+  type = string
+  sensitive = true
+  description = "password for Pfx File"
+  default = null
 }

--- a/modules/azure/key_vault_cetificate/main.tf
+++ b/modules/azure/key_vault_cetificate/main.tf
@@ -21,6 +21,16 @@ resource "azurerm_key_vault_certificate" "certificate" {
       name = "Self"
     }
 
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
     key_properties {
       exportable = true
       key_size   = var.key_properties.key_size

--- a/modules/azure/key_vault_cetificate/main.tf
+++ b/modules/azure/key_vault_cetificate/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_version = ">=1.1.2"
+
+  required_providers {
+    azurerm = "=2.94.0"
+  }
+
+  backend "azurerm" {}
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_key_vault_certificate" "certificate" {
+  name         = var.name
+  key_vault_id = var.key_vault_id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = var.key_properties.key_size
+      key_type   = var.key_properties.key_type
+      reuse_key  = true
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      key_usage = [
+        "cRLSign",
+      ]
+      subject_alternative_names {
+        dns_names = ["PleaseChangeMe.contoso.com"]
+      }
+      subject            = "CN=PleaseChangeMe"
+      validity_in_months = 12
+    }
+  }
+}

--- a/modules/azure/key_vault_cetificate/main.tf
+++ b/modules/azure/key_vault_cetificate/main.tf
@@ -37,9 +37,9 @@ resource "azurerm_key_vault_certificate" "certificate" {
         "cRLSign",
       ]
       subject_alternative_names {
-        dns_names = ["PleaseChangeMe.contoso.com"]
+        dns_names = var.dns_names
       }
-      subject            = "CN=PleaseChangeMe"
+      subject            = var.subject
       validity_in_months = 12
     }
   }

--- a/modules/azure/key_vault_cetificate/outputs.tf
+++ b/modules/azure/key_vault_cetificate/outputs.tf
@@ -1,0 +1,15 @@
+output "name" {
+  value = var.name
+}
+
+output "secret_id" {
+  value = azurerm_key_vault_certificate.certificate.secret_id
+}
+
+output "versionless_secret_id" {
+  value = azurerm_key_vault_certificate.certificate.versionless_secret_id
+}
+
+output "id" {
+  value = azurerm_key_vault_certificate.certificate.id
+}

--- a/modules/azure/key_vault_cetificate/variables.tf
+++ b/modules/azure/key_vault_cetificate/variables.tf
@@ -20,3 +20,14 @@ variable "key_properties" {
     key_type = "RSA"
   }
 }
+
+variable "dns_names"{
+  type = list(string)
+  description = "List of dns names for the certificate"
+  default = []
+}
+
+variable "subject" {
+  type = string
+  description = "Certificate Subject"
+} 

--- a/modules/azure/key_vault_cetificate/variables.tf
+++ b/modules/azure/key_vault_cetificate/variables.tf
@@ -1,0 +1,22 @@
+variable "name" {
+  type        = string
+  description = "Name of the certificate"
+}
+
+variable "key_vault_id" {
+  type        = string
+  description = "Key vault ID"
+}
+
+variable "key_properties" {
+  type = object({
+    key_size = number,
+    key_type = string
+  })
+  description = "key properties for certificate_policy of Certificate"
+
+  default = {
+    key_size = "4096"
+    key_type = "RSA"
+  }
+}


### PR DESCRIPTION
Create a couple of terraform modules: 
APIM_certificate to be able to add Certificates to the Backend Services. 
Keyvault_Certificate module -> to create some junk Certificate with default data such as:  
   subject   = "CN=PleaseChangeMe"
   
Since we anyway will not upload pfx files to source code I decided to not add extensive configuration options. The Developer during deployments would just have to manually assign a proper Certificate after deoloyment.
