### PR TITLE
Synapse managed private endpoints and mssql upgrade

### DIFF
--- a/modules/azure/mssql/main.tf
+++ b/modules/azure/mssql/main.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">=1.1.2"
+  required_version = ">=1.3.4"
 
   required_providers {
-    azurerm = "=3.16.0"
+    azurerm = "=3.36.0"
   }
 
   backend "azurerm" {}
@@ -100,7 +100,7 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   // log_analytics_destination_type = "Dedicated"
 
   dynamic "log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].logs
+    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
 
     content {
       category = log.value

--- a/modules/azure/mssql/outputs.tf
+++ b/modules/azure/mssql/outputs.tf
@@ -10,6 +10,10 @@ output "server_name" {
   value = azurerm_mssql_server.mssql_server.name
 }
 
+output "server_id" {
+  value = azurerm_mssql_server.mssql_server.id
+}
+
 output "server_fqdn" {
   value = azurerm_mssql_server.mssql_server.fully_qualified_domain_name
 }

--- a/modules/azure/synapse_workspace/main.tf
+++ b/modules/azure/synapse_workspace/main.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">=1.3.2"
+  required_version = ">=1.3.4"
 
   required_providers {
-    azurerm = "=3.31.0"
+    azurerm = "=3.36.0"
   }
 
   backend "azurerm" {}
@@ -154,3 +154,17 @@ resource "azurerm_synapse_role_assignment" "role_assignment" {
     azurerm_synapse_firewall_rule.firewall_rule
   ]
 }
+
+resource "azurerm_synapse_managed_private_endpoint" "managed_private_endpoints" {
+  for_each = {
+    for endpoint in var.managed_private_endpoints :
+    endpoint.resource_name => endpoint
+  }
+  name                 = "mpep-${each.value.resource_name}"
+  synapse_workspace_id = azurerm_synapse_workspace.workspace.id
+  target_resource_id   = each.value.resource_id
+  subresource_name     = each.value.subresource_name
+
+  depends_on = [azurerm_synapse_firewall_rule.firewall_rule]
+}
+

--- a/modules/azure/synapse_workspace/variables.tf
+++ b/modules/azure/synapse_workspace/variables.tf
@@ -120,3 +120,13 @@ variable "log_analytics_workspace_id" {
   description = "ID of a log analytics workspace (optional)."
   default     = null
 }
+
+variable "managed_private_endpoints" {
+  type = list(object({
+    resource_name    = string
+    resource_id      = string
+    subresource_name = string
+  }))
+  description = "List of managed private endpoints for the Synapse workspace."
+  default     = []
+}


### PR DESCRIPTION
Non-breaking changes:
* Upgrade `mssql` module to output server_id and upgrade azurerm version
* Upgrade `synapse_workspace` module to include optional managed private endpoints