### PR TITLE
Avoid deployment differences in deployed component

### DIFF
--- a/modules/azure/api_connectors/service_bus_managed_identity/connection.json
+++ b/modules/azure/api_connectors/service_bus_managed_identity/connection.json
@@ -4,7 +4,6 @@
   "parameters": {
     "location": {
       "type": "String",
-      "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "location"
       }

--- a/modules/azure/api_connectors/service_bus_managed_identity/connection.json
+++ b/modules/azure/api_connectors/service_bus_managed_identity/connection.json
@@ -1,29 +1,22 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "0.9.1.41621",
-      "templateHash": "14233748139416635108"
-    }
-  },
   "parameters": {
     "location": {
-      "type": "string",
+      "type": "String",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "location"
       }
     },
     "service_bus_connection_name": {
-      "type": "string",
+      "type": "String",
       "metadata": {
         "description": "Name to use for this connection"
       }
     },
     "service_bus_namespace_endpoint": {
-      "type": "string",
+      "type": "String",
       "metadata": {
         "description": "Service Bus namespace"
       }

--- a/modules/azure/api_connectors/service_bus_managed_identity/main.tf
+++ b/modules/azure/api_connectors/service_bus_managed_identity/main.tf
@@ -27,6 +27,9 @@ resource "azurerm_resource_group_template_deployment" "service_bus_managed_ident
     "service_bus_namespace_endpoint" = {
       value = var.service_bus_namespace_endpoint
     }
+    "location" = {
+      value = var.location
+    }
   })
   deployment_mode = "Incremental"
 }

--- a/modules/azure/api_connectors/service_bus_managed_identity/variables.tf
+++ b/modules/azure/api_connectors/service_bus_managed_identity/variables.tf
@@ -16,5 +16,4 @@ variable "service_bus_namespace_endpoint" {
 variable "location" {
   type        = string
   description = "The location of the connector, set by Azure if not provided and used to avoid deployment differences."
-  default     = "westeurope"
 }

--- a/modules/azure/api_connectors/service_bus_managed_identity/variables.tf
+++ b/modules/azure/api_connectors/service_bus_managed_identity/variables.tf
@@ -12,3 +12,9 @@ variable "service_bus_namespace_endpoint" {
   type        = string
   description = "The namespace endpoint for the connected service bus"
 }
+
+variable "location" {
+  type        = string
+  description = "The location of the connector, set by Azure if not provided and used to avoid deployment differences."
+  default     = "westeurope"
+}


### PR DESCRIPTION
This change results in a significantly lower deployment time.
Connectors don't really change, and were constantly being re-created in every deployment.

**Before**

![image](https://user-images.githubusercontent.com/106074602/221187554-0c3a138d-848b-4228-bb8f-6ad6a63bbad9.png)

**After**

<img width="435" alt="image" src="https://user-images.githubusercontent.com/106074602/221187616-98527ed2-080c-4be9-837a-348299074651.png">
