### PR TITLE
Update logic app standard variables

### DIFF
--- a/modules/azure/logic_app_standard/main.tf
+++ b/modules/azure/logic_app_standard/main.tf
@@ -27,6 +27,8 @@ resource "azurerm_logic_app_standard" "app" {
   location            = var.location
   resource_group_name = var.resource_group_name
   enabled             = var.enabled
+  https_only          = var.https_only
+  version             = var.version
 
   dynamic "identity" {
     for_each = var.use_managed_identity ? [1] : []

--- a/modules/azure/logic_app_standard/main.tf
+++ b/modules/azure/logic_app_standard/main.tf
@@ -44,7 +44,7 @@ resource "azurerm_logic_app_standard" "app" {
   }
 
   app_settings = merge({
-    WEBSITE_NODE_DEFAULT_VERSION = "~14",
+    WEBSITE_NODE_DEFAULT_VERSION = "~18",
     FUNCTIONS_WORKER_RUNTIME     = "node",
   }, var.app_settings)
 

--- a/modules/azure/logic_app_standard/outputs.tf
+++ b/modules/azure/logic_app_standard/outputs.tf
@@ -5,3 +5,7 @@ output "principal_id" {
 output "name" {
   value = azurerm_logic_app_standard.app.name
 }
+
+output "default_hostname" {
+  value = azurerm_logic_app_standard.app.default_hostname
+}

--- a/modules/azure/logic_app_standard/variables.tf
+++ b/modules/azure/logic_app_standard/variables.tf
@@ -76,13 +76,13 @@ variable "deployment_wait_timeout" {
 }
 
 variable "https_only" {
-  type = bool
+  type        = bool
   description = "Allow only HTTPS access."
-  default = false
+  default     = false
 }
 
 variable "version" {
-  type = string
-  description = "The runtime version associated with the Logic App"
-  default = "~3"
+  type        = string
+  description = "The runtime version associated with the Logic App."
+  default     = "~3"
 }

--- a/modules/azure/logic_app_standard/variables.tf
+++ b/modules/azure/logic_app_standard/variables.tf
@@ -84,5 +84,5 @@ variable "https_only" {
 variable "version" {
   type        = string
   description = "The runtime version associated with the Logic App."
-  default     = "~3"
+  default     = "~4"
 }

--- a/modules/azure/logic_app_standard/variables.tf
+++ b/modules/azure/logic_app_standard/variables.tf
@@ -74,3 +74,15 @@ variable "deployment_wait_timeout" {
   description = "The amount of time to wait for the deployment to start after the logic app was deployed."
   default     = 30
 }
+
+variable "https_only" {
+  type = bool
+  description = "Allow only HTTPS access."
+  default = false
+}
+
+variable "version" {
+  type = string
+  description = "The runtime version associated with the Logic App"
+  default = "~3"
+}


### PR DESCRIPTION
- Added 'default_hostname' to outupt variables to be able to reference logic app http endpoint.
- Added 'https_only' to input variables to be able to allow only HTTPS connections to logic app http endpoint.
- Added 'version' to input variables to be able to change runtime version. Also updated default runtime version to ~4. Version ~3 will be out of support since April.
- Updated default value of node.js from 14 to 18. Version 14 will be out of support since April.