### PR TITLE
chage default value of SB subscription lock_duration

### DIFF
--- a/modules/azure/service_bus_subscription/variables.tf
+++ b/modules/azure/service_bus_subscription/variables.tf
@@ -17,7 +17,7 @@ variable "max_delivery_count" {
 variable "lock_duration" {
   type        = string # ISO 8601
   description = "The lock duration for the subscription."
-  default     = "P0DT0H1M0S"
+  default     = "PT1M"
 }
 
 variable "requires_session" {


### PR DESCRIPTION
Chage default value of SB subscription lock_duration to shortened form to prevent updating resource at every terraform apply run.

![image](https://user-images.githubusercontent.com/122079792/230778938-b283b16e-c580-4033-8138-6f248b16648e.png)
