### PR TITLE
v3.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Common Changelog](https://common-changelog.org),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2023-04-11
+
+### Changed
+
+- `azure/service_bus_subscription`: Change default of variable `lock_duration` from `P0DT0H1M0S` to `PT1M` ([#304](https://github.com/recognizegroup/terraform/pull/304)) ([`3b50ca39`](https://github.com/recognizegroup/terraform/commit/3b50ca39))
+
+### Added
+
+- `azure/function_app_linux`: Add variable `use_32_bit_worker` ([#305](https://github.com/recognizegroup/terraform/pull/305)) ([`1cf8b62b`](https://github.com/recognizegroup/terraform/commit/1cf8b62b))
+- `azure/function_app_linux_managed_identity`: Add variable `use_32_bit_worker` ([#305](https://github.com/recognizegroup/terraform/pull/305)) ([`1cf8b62b`](https://github.com/recognizegroup/terraform/commit/1cf8b62b))
+- `azure/function_app_windows`: Add variable `use_32_bit_worker` ([#305](https://github.com/recognizegroup/terraform/pull/305)) ([`1cf8b62b`](https://github.com/recognizegroup/terraform/commit/1cf8b62b))
+
 ## [3.1.0] - 2023-04-05
 
 ### Added
@@ -77,4 +89,6 @@ _If you are upgrading: please see [UPGRADE_3.0.md](UPGRADE_3.0.md)._
 - **Breaking:** Remove module `azure/monitoring`, replace with `azure/azure/monitoring_action_group` and `azure/monitoring_log_analytics_alert` ([#268](https://github.com/recognizegroup/terraform/pull/268)) ([`5bd013c1`](https://github.com/recognizegroup/terraform/commit/5bd013c1))
 - **Breaking:** Remove module `azure/api_connectors/storage_account`, replace with `azure/api_connectors/storage_blob` and `azure/api_connectors/storage_table` ([#276](https://github.com/recognizegroup/terraform/pull/276)) ([`7a483886`](https://github.com/recognizegroup/terraform/commit/7a483886))
 
+[3.2.0]: https://github.com/recognizegroup/terraform/releases/tag/v3.2.0
+[3.1.0]: https://github.com/recognizegroup/terraform/releases/tag/v3.1.0
 [3.0.0]: https://github.com/recognizegroup/terraform/releases/tag/v3.0.0

--- a/modules/azure/function_app_linux/main.tf
+++ b/modules/azure/function_app_linux/main.tf
@@ -31,6 +31,7 @@ resource "azurerm_linux_function_app" "function_app" {
   site_config {
     always_on              = var.always_on
     vnet_route_all_enabled = var.route_all_outbound_traffic
+    use_32_bit_worker      = var.use_32_bit_worker
 
     dynamic "ip_restriction" {
       for_each = var.ip_restrictions

--- a/modules/azure/function_app_linux/variables.tf
+++ b/modules/azure/function_app_linux/variables.tf
@@ -93,3 +93,9 @@ variable "ip_restrictions" {
   description = "A List of objects representing ip restrictions."
   default     = []
 }
+
+variable "use_32_bit_worker" {
+  type        = bool
+  description = "Should the Linux Web App use a 32-bit worker process."
+  default     = true
+}

--- a/modules/azure/function_app_linux_managed_identity/main.tf
+++ b/modules/azure/function_app_linux_managed_identity/main.tf
@@ -55,6 +55,7 @@ resource "azurerm_linux_function_app" "function_app" {
   site_config {
     always_on              = var.always_on
     vnet_route_all_enabled = var.route_all_outbound_traffic
+    use_32_bit_worker      = var.use_32_bit_worker
 
     dynamic "ip_restriction" {
       for_each = var.ip_restrictions

--- a/modules/azure/function_app_linux_managed_identity/variables.tf
+++ b/modules/azure/function_app_linux_managed_identity/variables.tf
@@ -138,3 +138,9 @@ variable "authentication_settings" {
     excluded_paths         = []
   }
 }
+
+variable "use_32_bit_worker" {
+  type        = bool
+  description = "Should the Linux Web App use a 32-bit worker process."
+  default     = true
+}

--- a/modules/azure/function_app_windows/main.tf
+++ b/modules/azure/function_app_windows/main.tf
@@ -31,6 +31,7 @@ resource "azurerm_windows_function_app" "function_app" {
   site_config {
     always_on              = var.always_on
     vnet_route_all_enabled = var.route_all_outbound_traffic
+    use_32_bit_worker      = var.use_32_bit_worker
 
     dynamic "ip_restriction" {
       for_each = var.ip_restrictions

--- a/modules/azure/function_app_windows/variables.tf
+++ b/modules/azure/function_app_windows/variables.tf
@@ -93,3 +93,9 @@ variable "ip_restrictions" {
   description = "A List of objects representing ip restrictions."
   default     = []
 }
+
+variable "use_32_bit_worker" {
+  type        = bool
+  description = "Should the Windows Function App use a 32-bit worker process."
+  default     = true
+}

--- a/modules/azure/service_bus_subscription/variables.tf
+++ b/modules/azure/service_bus_subscription/variables.tf
@@ -17,7 +17,7 @@ variable "max_delivery_count" {
 variable "lock_duration" {
   type        = string # ISO 8601
   description = "The lock duration for the subscription."
-  default     = "P0DT0H1M0S"
+  default     = "PT1M"
 }
 
 variable "requires_session" {


### PR DESCRIPTION
### Changed

- `azure/service_bus_subscription`: Change default of variable `lock_duration` from `P0DT0H1M0S` to `PT1M` ([#304](https://github.com/recognizegroup/terraform/pull/304)) ([`3b50ca39`](https://github.com/recognizegroup/terraform/commit/3b50ca39))

### Added

- `azure/function_app_linux`: Add variable `use_32_bit_worker` ([#305](https://github.com/recognizegroup/terraform/pull/305)) ([`1cf8b62b`](https://github.com/recognizegroup/terraform/commit/1cf8b62b))
- `azure/function_app_linux_managed_identity`: Add variable `use_32_bit_worker` ([#305](https://github.com/recognizegroup/terraform/pull/305)) ([`1cf8b62b`](https://github.com/recognizegroup/terraform/commit/1cf8b62b))
- `azure/function_app_windows`: Add variable `use_32_bit_worker` ([#305](https://github.com/recognizegroup/terraform/pull/305)) ([`1cf8b62b`](https://github.com/recognizegroup/terraform/commit/1cf8b62b))