### PR TITLE
TD-590 Add minimums for passwords

### DIFF
--- a/modules/azure/mssql/main.tf
+++ b/modules/azure/mssql/main.tf
@@ -22,6 +22,10 @@ resource "random_password" "mssql_admin_password" {
   special          = true
   override_special = "_%@"
   keepers          = var.password_keeper
+  min_lower        = 1
+  min_upper        = 1
+  min_numeric      = 1
+  min_special      = 1
 }
 
 resource "azurerm_mssql_server" "mssql_server" {

--- a/modules/azure/mysql/main.tf
+++ b/modules/azure/mysql/main.tf
@@ -20,6 +20,10 @@ resource "random_password" "mysql_admin_password" {
   special          = true
   override_special = "_%@"
   keepers          = var.password_keeper
+  min_lower        = 1
+  min_upper        = 1
+  min_numeric      = 1
+  min_special      = 1
 }
 
 resource "azurerm_mysql_server" "mysql_server" {

--- a/modules/azure/mysql_flexible_server/main.tf
+++ b/modules/azure/mysql_flexible_server/main.tf
@@ -20,6 +20,10 @@ resource "random_password" "mysql_admin_password" {
   special          = true
   override_special = "_%@"
   keepers          = var.password_keeper
+  min_lower        = 1
+  min_upper        = 1
+  min_numeric      = 1
+  min_special      = 1
 }
 
 resource "azurerm_mysql_flexible_server" "mysql_flexible_server" {

--- a/modules/azure/mysql_flexible_server_public/main.tf
+++ b/modules/azure/mysql_flexible_server_public/main.tf
@@ -20,6 +20,10 @@ resource "random_password" "mysql_admin_password" {
   special          = true
   override_special = "_%@"
   keepers          = var.password_keeper
+  min_lower        = 1
+  min_upper        = 1
+  min_numeric      = 1
+  min_special      = 1
 }
 
 resource "azurerm_mysql_flexible_server" "mysql_flexible_server" {

--- a/modules/azure/postgresql/main.tf
+++ b/modules/azure/postgresql/main.tf
@@ -20,6 +20,10 @@ resource "random_password" "postgresql_admin" {
   special          = false
   override_special = "_%@"
   keepers          = var.password_keeper
+  min_lower        = 1
+  min_upper        = 1
+  min_numeric      = 1
+  min_special      = 1
 }
 
 resource "azurerm_postgresql_flexible_server" "postgresql_server" {

--- a/modules/azure/postgresql_public/main.tf
+++ b/modules/azure/postgresql_public/main.tf
@@ -20,6 +20,10 @@ resource "random_password" "postgresql_admin" {
   special          = false
   override_special = "_%@"
   keepers          = var.password_keeper
+  min_lower        = 1
+  min_upper        = 1
+  min_numeric      = 1
+  min_special      = 1
 }
 
 resource "azurerm_postgresql_flexible_server" "postgresql_server" {

--- a/modules/azure/synapse_workspace/main.tf
+++ b/modules/azure/synapse_workspace/main.tf
@@ -37,6 +37,11 @@ resource "random_password" "sql_admin_password" {
   upper            = true
   numeric          = true
   override_special = "_%@"
+  min_lower        = 1
+  min_upper        = 1
+  min_numeric      = 1
+  min_special      = 1
+
   keepers = {
     keeper = var.sql_admin_password_keeper
   }

--- a/modules/other/password_generator/main.tf
+++ b/modules/other/password_generator/main.tf
@@ -9,8 +9,8 @@ resource "random_password" "password" {
   special          = true
   override_special = "_%@"
   keepers          = var.password_keeper
-  min_lower        = 1
-  min_upper        = 1
-  min_numeric      = 1
-  min_special      = 1
+  min_lower        = var.min_lower
+  min_upper        = var.min_upper
+  min_numeric      = var.min_numeric
+  min_special      = var.min_special
 }

--- a/modules/other/password_generator/main.tf
+++ b/modules/other/password_generator/main.tf
@@ -9,4 +9,8 @@ resource "random_password" "password" {
   special          = true
   override_special = "_%@"
   keepers          = var.password_keeper
+  min_lower        = 1
+  min_upper        = 1
+  min_numeric      = 1
+  min_special      = 1
 }

--- a/modules/other/password_generator/variables.tf
+++ b/modules/other/password_generator/variables.tf
@@ -8,3 +8,27 @@ variable "password_keeper" {
   type        = map(string)
   description = "Random map of strings, when changed the password will rotate."
 }
+
+variable "min_lower" {
+  type        = number
+  description = "Minimum number of lower case characters of the password."
+  default     = 0
+}
+
+variable "min_upper" {
+  type        = number
+  description = "Minimum number of upper case characters of the password."
+  default     = 0
+}
+
+variable "min_numeric" {
+  type        = number
+  description = "Minimum number of numeric characters of the password."
+  default     = 0
+}
+
+variable "min_special" {
+  type        = number
+  description = "Minimum number of special characters of the password."
+  default     = 0
+}


### PR DESCRIPTION
I got an error because the password only had lower and upper case letters.

```
╷
│ Error: "administrator_password" must contain characters from three of the categories – uppercase letters, lowercase letters, numbers and non-alphanumeric characters, got ### REDACTED PASSWORD THAT ONLY HAS LOWER AND UPPERCASE LETTERS ###
│ 
│   with azurerm_mysql_flexible_server.mysql_flexible_server,
│   on main.tf line 31, in resource "azurerm_mysql_flexible_server" "mysql_flexible_server":
│   31:   administrator_password = random_password.mysql_admin_password.result
│ 
╵
```