### PR TITLE
TD-592 - Use the correct variable for the port

### DIFF
--- a/modules/kubernetes/deployment_with_service/main.tf
+++ b/modules/kubernetes/deployment_with_service/main.tf
@@ -203,7 +203,7 @@ resource "kubernetes_manifest" "http-scaler" {
       scaleTargetRef = {
         deployment = var.name
         service    = var.name
-        port       = var.target_port
+        port       = var.container_port
       }
 
       replicas = {


### PR DESCRIPTION
Changelog:
```md
### Fixed

- `kubernetes/deployment_with_service`: Fix bug where the http-scaler used the wrong port (#333) (270e3947) (@tom-reinders)
```