### PR TITLE
Logic App OAuth policy in HTTP trigger

### DIFF
--- a/modules/azure/logic_app/main.tf
+++ b/modules/azure/logic_app/main.tf
@@ -38,15 +38,20 @@ resource "azurerm_logic_app_workflow" "workflow" {
 
   dynamic "access_control" {
     for_each = length(var.trigger_oauth_policy_claims) > 0 ? [1] : []
-    trigger {
-      open_authentication_policy {
-        name = "Default"
-        claim {
-          for_each = var.trigger_oauth_policy_claims
-          name     = each.key
-          value    = each.value
+    content {
+      trigger {
+        allowed_caller_ip_address_range = var.trigger_ip_address_range
+        open_authentication_policy {
+          name = "Default"
+          dynamic "claim" {
+            for_each = var.trigger_oauth_policy_claims
+            content {
+              name  = claim.key
+              value = claim.value        
+            }
+          }
         }
-      }
+      }      
     }
   }
 }

--- a/modules/azure/logic_app/main.tf
+++ b/modules/azure/logic_app/main.tf
@@ -47,11 +47,11 @@ resource "azurerm_logic_app_workflow" "workflow" {
             for_each = var.trigger_oauth_policy_claims
             content {
               name  = claim.key
-              value = claim.value        
+              value = claim.value
             }
           }
         }
-      }      
+      }
     }
   }
 }

--- a/modules/azure/logic_app/main.tf
+++ b/modules/azure/logic_app/main.tf
@@ -35,6 +35,20 @@ resource "azurerm_logic_app_workflow" "workflow" {
       type = "SystemAssigned"
     }
   }
+
+  dynamic "access_control" {
+    for_each = length(var.trigger_oauth_policy_claims) > 0 ? [1] : []
+    trigger {
+      open_authentication_policy {
+        name       = "Default"
+        claim {
+          for_each = var.trigger_oauth_policy_claims
+          name     = each.key
+          value    = each.value
+        }        
+      }
+    }
+  }
 }
 
 // Deploy workflow as ARM template conditional when arm_template_path is specified

--- a/modules/azure/logic_app/main.tf
+++ b/modules/azure/logic_app/main.tf
@@ -40,12 +40,12 @@ resource "azurerm_logic_app_workflow" "workflow" {
     for_each = length(var.trigger_oauth_policy_claims) > 0 ? [1] : []
     trigger {
       open_authentication_policy {
-        name       = "Default"
+        name = "Default"
         claim {
           for_each = var.trigger_oauth_policy_claims
           name     = each.key
           value    = each.value
-        }        
+        }
       }
     }
   }

--- a/modules/azure/logic_app/variables.tf
+++ b/modules/azure/logic_app/variables.tf
@@ -51,6 +51,12 @@ variable "use_managed_identity" {
 
 variable "trigger_oauth_policy_claims" {
   type        = map(string)
-  description = "Claims validated by open authentication policy in HTTP trigger"
+  description = "Claims validated by OAuth policy in HTTP trigger"
   default     = {}
+}
+
+variable "trigger_ip_address_range" {
+  type        = set(string)
+  description = "IP address range allowed to call HTTP trigger"
+  default     = [ "0.0.0.0/0" ]
 }

--- a/modules/azure/logic_app/variables.tf
+++ b/modules/azure/logic_app/variables.tf
@@ -58,5 +58,5 @@ variable "trigger_oauth_policy_claims" {
 variable "trigger_ip_address_range" {
   type        = set(string)
   description = "IP address range allowed to call HTTP trigger"
-  default     = [ "0.0.0.0/0" ]
+  default     = ["0.0.0.0/0"]
 }

--- a/modules/azure/logic_app/variables.tf
+++ b/modules/azure/logic_app/variables.tf
@@ -48,3 +48,9 @@ variable "use_managed_identity" {
   description = "Use Managed Identity for this logic app"
   default     = false
 }
+
+variable "trigger_oauth_policy_claims" {
+  type        = map(string)
+  description = "Trigger open authentication policy validated claims"
+  default     = {}
+}

--- a/modules/azure/logic_app/variables.tf
+++ b/modules/azure/logic_app/variables.tf
@@ -51,6 +51,6 @@ variable "use_managed_identity" {
 
 variable "trigger_oauth_policy_claims" {
   type        = map(string)
-  description = "Trigger open authentication policy validated claims"
+  description = "Claims validated by open authentication policy in HTTP trigger"
   default     = {}
 }


### PR DESCRIPTION
Added dynamic `access_control` section into `azurerm_logic_app_workflow` resource to enable validation of JWT used to authorize HTTP trigger of Logic App. Implementing this change is possible to trigger Logic App using HTTP trigger without SAS tokens. Configured properties are visible on Authorization blade of Logic App in Azure Portal. Example usage of `trigger_oauth_policy_claims`:
```
trigger_oauth_policy_claims = {
  iss   = "https://sts.windows.net/${include.locals.env.authorization_tenant}/"
  aud   = "api://app-${include.locals.client}-${include.locals.workload}-projectsync-${include.locals.environment}"
  roles = "Default.Access"
}
```

Changelog:
```md
### Added

- `azure/logic_app`: Add variable `trigger_oauth_policy_claims` (#340) (e2381256) (@mkostalrecognize)
- `azure/logic_app`: Add variable `trigger_ip_address_range` (#340) (31477279) (@mkostalrecognize)
```