### PR TITLE
TD-596 - Add output with correct name for primary_connection_string

### DIFF
--- a/modules/azure/storage_account_private/outputs.tf
+++ b/modules/azure/storage_account_private/outputs.tf
@@ -15,6 +15,11 @@ output "primary_access_key" {
   sensitive = true
 }
 
+output "primary_connection_string" {
+  value     = azurerm_storage_account.storage_account.primary_connection_string
+  sensitive = true
+}
+
 output "primary_access_connection_string" {
   value     = azurerm_storage_account.storage_account.primary_connection_string
   sensitive = true

--- a/modules/azure/storage_account_private/outputs.tf
+++ b/modules/azure/storage_account_private/outputs.tf
@@ -20,7 +20,10 @@ output "primary_connection_string" {
   sensitive = true
 }
 
+# Deprecated in favor of primary_connection_string
+# TODO: Remove deprecated output in next major version
 output "primary_access_connection_string" {
-  value     = azurerm_storage_account.storage_account.primary_connection_string
-  sensitive = true
+  description = "Deprecated in favor of primary_connection_string"
+  value       = azurerm_storage_account.storage_account.primary_connection_string
+  sensitive   = true
 }

--- a/modules/azure/storage_account_public/outputs.tf
+++ b/modules/azure/storage_account_public/outputs.tf
@@ -15,6 +15,11 @@ output "primary_access_key" {
   sensitive = true
 }
 
+output "primary_connection_string" {
+  value     = azurerm_storage_account.storage_account.primary_connection_string
+  sensitive = true
+}
+
 output "primary_access_connection_string" {
   value     = azurerm_storage_account.storage_account.primary_connection_string
   sensitive = true

--- a/modules/azure/storage_account_public/outputs.tf
+++ b/modules/azure/storage_account_public/outputs.tf
@@ -20,7 +20,10 @@ output "primary_connection_string" {
   sensitive = true
 }
 
+# Deprecated in favor of primary_connection_string
+# TODO: Remove deprecated output in next major version
 output "primary_access_connection_string" {
-  value     = azurerm_storage_account.storage_account.primary_connection_string
-  sensitive = true
+  description = "Deprecated in favor of primary_connection_string"
+  value       = azurerm_storage_account.storage_account.primary_connection_string
+  sensitive   = true
 }


### PR DESCRIPTION
Changelog:
```md
### Added

- `azure/storage_account_private`: Add output `primary_connection_string` (#348) (ba78e538) (@tom-reinders)
- `azure/storage_account_public`: Add output `primary_connection_string` (#348) (ba78e538) (@tom-reinders)
```