### PR TITLE
MOD-1112 - Allow setting key vault access policy without current principal

### DIFF
--- a/modules/azure/key_vault/main.tf
+++ b/modules/azure/key_vault/main.tf
@@ -31,7 +31,7 @@ resource "azurerm_key_vault" "key_vault" {
   // Set secrets administrator policy
   dynamic "access_policy" {
     for_each = {
-      for index, object_id in distinct(concat(var.secret_administrators, [data.azurerm_client_config.current.object_id])) :
+      for index, object_id in distinct(concat(var.secret_administrators, var.add_current_principal_as_administrator ? [] : [data.azurerm_client_config.current.object_id])) :
       object_id => object_id if !var.enable_rbac
     }
 

--- a/modules/azure/key_vault/variables.tf
+++ b/modules/azure/key_vault/variables.tf
@@ -60,3 +60,9 @@ variable "log_analytics_workspace_id" {
   description = "ID of a log analytics workspace (optional)."
   default     = null
 }
+
+variable "add_current_principal_as_administrator" {
+  type        = bool
+  description = "Flag to specify whether to add the current principal as administrator."
+  default     = true # This default behavior is to maintain backwards compatibility.
+}


### PR DESCRIPTION
Changelog:
```md
### Added

- `azure/key_vault`: Add variable `add_current_principal_as_administrator` (#353) (0a3492f3) (@bartwesselink)
```