### PR TITLE
Modifying kv secrets put once to read existing secrets AB#17461

### DIFF
--- a/modules/azure/key_vault_secrets_put_once/main.tf
+++ b/modules/azure/key_vault_secrets_put_once/main.tf
@@ -29,3 +29,8 @@ resource "azurerm_key_vault_secret" "secret" {
     ignore_changes = [value]
   }
 }
+
+data "azurerm_key_vault_secret" "secret" {
+  name         = var.secret_name
+  key_vault_id = var.key_vault_id
+}

--- a/modules/azure/key_vault_secrets_put_once/outputs.tf
+++ b/modules/azure/key_vault_secrets_put_once/outputs.tf
@@ -1,0 +1,4 @@
+output "key_vault_secret_value" {
+  value     = data.azurerm_key_vault_secret.secret.value
+  sensitive = true
+}

--- a/modules/azure/key_vault_secrets_put_once/variables.tf
+++ b/modules/azure/key_vault_secrets_put_once/variables.tf
@@ -12,3 +12,8 @@ variable "key_vault_id" {
   type        = string
   description = "ID of the key vault."
 }
+
+variable "secret_name" {
+  type        = string
+  description = "The secret name."
+}


### PR DESCRIPTION
The  kv secrets put once module is the main module being used for storing secret values.

However, there are situations ( for stream analytics for example) where the other module - kv secrets is being used.

https://github.com/recognizegroup/vwt-ip-ns-integration/blob/develop/terraform/modules/stream_analytics/terragrunt.hcl

That module does not have secret protection, it does have output values but uses data provider and not resource provider.

This causes problems, it appears this is some 'old' way ...

The module primarily used for kv secrets- key_vault_secrets_put_once - was augmented and data provider functionality was added.
That way the module runs and creates the secrets and protects them for being rewritten. But also reads the existing secrets.
In the same way how the 'older' - key_vault_secrets - module does it with the data provider.

This should make it more flexible especially for using with stream analytics.