### PR TITLE
Created a module for rewritable storage table rows

### DIFF
--- a/modules/azure/storage_table_entities_rewritable/main.tf
+++ b/modules/azure/storage_table_entities_rewritable/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = "~> 1.3"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.48"
+    }
+  }
+
+  backend "azurerm" {}
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_storage_table_entity" "storage_table_entity" {
+  for_each = { for entity in var.rows : entity.row_key => entity }
+
+  table_name           = var.storage_table_name
+  storage_account_name = var.storage_account_name
+
+  partition_key = each.value.partition_key
+  row_key       = each.value.row_key
+
+  entity = each.value.entity
+}

--- a/modules/azure/storage_table_entities_rewritable/variables.tf
+++ b/modules/azure/storage_table_entities_rewritable/variables.tf
@@ -1,0 +1,18 @@
+variable "storage_account_name" {
+  type        = string
+  description = "Name of the storage account"
+}
+
+variable "storage_table_name" {
+  type        = string
+  description = "Name of the storage table"
+}
+
+variable "rows" {
+  type = set(object({
+    partition_key = string
+    row_key       = string
+    entity        = any
+  }))
+  description = "Rows to insert into the table. Every entry should contain a partition key, a row key and a set of properties. Rows are updated by TF if definition changes, rewriting whatever value is in Storage Table"
+}


### PR DESCRIPTION
The current storage_tables_entries module is useful for a one-time setting of values because of a lifecycle ignore_changes flag. This one should update values whenever the entity changes in the repo.