### PR TITLE
Expose key vault secrets values as sensitive AB#18306

### DIFF
--- a/modules/azure/key_vault_secrets_put_once/main.tf
+++ b/modules/azure/key_vault_secrets_put_once/main.tf
@@ -29,13 +29,3 @@ resource "azurerm_key_vault_secret" "secret" {
     ignore_changes = [value]
   }
 }
-
-data "azurerm_key_vault_secret" "secrets" {
-  for_each = {
-    for index, secret in nonsensitive(var.secrets) :
-    secret.secret_name => secret
-  }
-
-  name         = each.value.secret_name
-  key_vault_id = var.key_vault_id
-}

--- a/modules/azure/key_vault_secrets_put_once/main.tf
+++ b/modules/azure/key_vault_secrets_put_once/main.tf
@@ -29,3 +29,13 @@ resource "azurerm_key_vault_secret" "secret" {
     ignore_changes = [value]
   }
 }
+
+data "azurerm_key_vault_secret" "secrets" {
+  for_each = {
+    for index, secret in nonsensitive(var.secrets) :
+    secret.secret_name => secret
+  }
+
+  name         = each.value.secret_name
+  key_vault_id = var.key_vault_id
+}

--- a/modules/azure/key_vault_secrets_put_once/outputs.tf
+++ b/modules/azure/key_vault_secrets_put_once/outputs.tf
@@ -1,0 +1,7 @@
+output "secrets" {
+  value = {
+    for prop in values(data.azurerm_key_vault_secret.secrets)[*] :
+    prop.name => prop.value
+  }
+  sensitive = true
+}

--- a/modules/azure/key_vault_secrets_put_once/outputs.tf
+++ b/modules/azure/key_vault_secrets_put_once/outputs.tf
@@ -1,6 +1,6 @@
 output "secrets" {
   value = {
-    for prop in values(data.azurerm_key_vault_secret.secrets)[*] :
+    for prop in values(resource.azurerm_key_vault_secret.secret)[*] :
     prop.name => prop.value
   }
   sensitive = true


### PR DESCRIPTION
The module is outputting the added secrets (sensitive in cmd, but reachable by dependency)

**C:\Users\.......\terraform\modules\key_vault_secrets> terragrunt apply**
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:
secrets = \<sensitive\>

**C:\Users\.......\terraform\modules\key_vault_secrets> terragrunt output secrets**
{
  "JournalEntriesCsvDumpSharepointAppRegKey" = "........"
  "NotificationSecret" = "........"
  "ServiceTicketsServiceEmailClientId" = "18645ff4......."
  "ServiceTicketsServiceEmailClientSecret" = "........"
  "SharepointAccessClientId" = "91e9dadb......."
  "SharepointAccessClientSecret" = "........."
}