### PR TITLE
Add id of secret in return for key_vault_secrets_put_once module

### DIFF
--- a/modules/azure/key_vault_secrets_put_once/outputs.tf
+++ b/modules/azure/key_vault_secrets_put_once/outputs.tf
@@ -1,7 +1,10 @@
 output "secrets" {
   value = {
     for prop in values(resource.azurerm_key_vault_secret.secret)[*] :
-    prop.name => prop.value
+    prop.name => {
+      value = prop.value
+      id = prop.id
+    }
   }
   sensitive = true
 }

--- a/modules/azure/key_vault_secrets_put_once/outputs.tf
+++ b/modules/azure/key_vault_secrets_put_once/outputs.tf
@@ -3,7 +3,7 @@ output "secrets" {
     for prop in values(resource.azurerm_key_vault_secret.secret)[*] :
     prop.name => {
       value = prop.value
-      id = prop.id
+      id    = prop.id
     }
   }
   sensitive = true


### PR DESCRIPTION
Usage: 
![image](https://github.com/recognizegroup/terraform/assets/138434864/2b009048-feba-4edf-aba9-aeed5f538e63)
It is helpful when retrieving the id of the secret.
