### PR TITLE
feat: Apply diagnostic settings changes once the deployment is finished

### DIFF
--- a/modules/azure/logic_app_standard/main.tf
+++ b/modules/azure/logic_app_standard/main.tf
@@ -121,6 +121,8 @@ data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
 }
 
 // Write logs and metrics to log analytics if specified
+// Needs to be done once the deployment is finished, because updating Diagnostic Settings leads to a restart of the Logic App
+// which causes the deployment to fail if it is not finished yet
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   depends_on = [
     null_resource.deploy

--- a/modules/azure/logic_app_standard/main.tf
+++ b/modules/azure/logic_app_standard/main.tf
@@ -122,6 +122,10 @@ data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
 
 // Write logs and metrics to log analytics if specified
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
+  depends_on = [
+    null_resource.deploy
+  ]
+
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.logic_app_name}"
   target_resource_id         = azurerm_logic_app_standard.app.id


### PR DESCRIPTION
For the stable release, the Diagnostic Settings need to be updated once the deployment is finished. Otherwise, it can happen that the Diagnostic Settings changes are finished first, which causes the restart of the Standard Logic App, which leads to a failed deployment
**Affected run**
https://github.com/recognizegroup/vwt-integrations-hub/actions/runs/12678885897/job/35343504598
![image](https://github.com/user-attachments/assets/b5629d58-eeb1-436a-a2a4-f020b82d5970)
**Related Kudu log**
```
<step title="Error occurred" date="2018-11-13T13:20:53.093" type="error" text="Thread was being aborted." stackTrace="   at System.Threading.Monitor.ObjWait(Boolean exitContext, Int32 millisecondsTimeout, Object obj)
   at System.Threading.Monitor.Wait(Object obj, Int32 millisecondsTimeout, Boolean exitContext)
   at System.Threading.Monitor.Wait(Object obj, Int32 millisecondsTimeout)
   at System.Threading.ManualResetEventSlim.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.SpinThenBlockingWait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.InternalWait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at System.Threading.Tasks.Task`1.get_Result()
   at Kudu.Core.Infrastructure.Executable.ExecuteInternal(ITracer tracer, Func`2 onWriteOutput, Func`2 onWriteError, Encoding encoding, String arguments, Object[] args) in C:\Kudu Files\Private\src\master\Kudu.Core\Infrastructure\Executable.cs:line 221
   at Kudu.Core.Infrastructure.Executable.ExecuteWithProgressWriter(ILogger logger, ITracer tracer, String arguments, Object[] args) in C:\Kudu Files\Private\src\master\Kudu.Core\Infrastructure\Executable.cs:line 144
   at Kudu.Core.Deployment.Generator.ExternalCommandBuilder.RunCommand(DeploymentContext context, String command, Boolean ignoreManifest, String message) in C:\Kudu Files\Private\src\master\Kudu.Core\Deployment\Generator\ExternalCommandBuilder.cs:line 96" />
```
**Fix references**
https://github.com/projectkudu/kudu/issues/3086#issuecomment-560597536
https://stackoverflow.com/a/43343090/5857392
