### PR TITLE
AB#31597 - added app_scale_limit into windows azure function module

### DIFF
--- a/modules/azure/function_app_windows/main.tf
+++ b/modules/azure/function_app_windows/main.tf
@@ -32,9 +32,7 @@ resource "azurerm_windows_function_app" "function_app" {
     always_on              = var.always_on
     vnet_route_all_enabled = var.route_all_outbound_traffic
     use_32_bit_worker      = var.use_32_bit_worker
-    
-    # Only set app_scale_limit if it's not null. Can be set to 0 or null for unrestricted, or a valid value between 1 and the app maximum
-    app_scale_limit        = var.app_scale_limit != null ? var.app_scale_limit : 0
+    app_scale_limit        = var.app_scale_limit == null ? 0 : var.app_scale_limit
 
     dynamic "application_stack" {
       for_each = var.dotnet_version != "" ? [1] : []

--- a/modules/azure/function_app_windows/main.tf
+++ b/modules/azure/function_app_windows/main.tf
@@ -32,7 +32,9 @@ resource "azurerm_windows_function_app" "function_app" {
     always_on              = var.always_on
     vnet_route_all_enabled = var.route_all_outbound_traffic
     use_32_bit_worker      = var.use_32_bit_worker
-    app_scale_limit        = var.app_scale_limit
+    
+    # Only set app_scale_limit if it's not null. Can be set to 0 or null for unrestricted, or a valid value between 1 and the app maximum
+    app_scale_limit        = var.app_scale_limit != null ? var.app_scale_limit : 0
 
     dynamic "application_stack" {
       for_each = var.dotnet_version != "" ? [1] : []

--- a/modules/azure/function_app_windows/main.tf
+++ b/modules/azure/function_app_windows/main.tf
@@ -32,7 +32,7 @@ resource "azurerm_windows_function_app" "function_app" {
     always_on              = var.always_on
     vnet_route_all_enabled = var.route_all_outbound_traffic
     use_32_bit_worker      = var.use_32_bit_worker
-    app_scale_limit        = var.app_scale_limit == null ? 0 : var.app_scale_limit
+    app_scale_limit        = var.app_scale_limit
 
     dynamic "application_stack" {
       for_each = var.dotnet_version != "" ? [1] : []

--- a/modules/azure/function_app_windows/main.tf
+++ b/modules/azure/function_app_windows/main.tf
@@ -32,6 +32,7 @@ resource "azurerm_windows_function_app" "function_app" {
     always_on              = var.always_on
     vnet_route_all_enabled = var.route_all_outbound_traffic
     use_32_bit_worker      = var.use_32_bit_worker
+    app_scale_limit        = var.app_scale_limit
 
     dynamic "application_stack" {
       for_each = var.dotnet_version != "" ? [1] : []

--- a/modules/azure/function_app_windows/variables.tf
+++ b/modules/azure/function_app_windows/variables.tf
@@ -115,6 +115,5 @@ variable "use_32_bit_worker" {
 variable "app_scale_limit" {
   type        = number
   description = "Number of workers this function app can scale out to. Only applicable to apps on the Consumption and Premium plan."
-  default     = null
-  nullable    = true
+  default     = 0
 }

--- a/modules/azure/function_app_windows/variables.tf
+++ b/modules/azure/function_app_windows/variables.tf
@@ -115,5 +115,6 @@ variable "use_32_bit_worker" {
 variable "app_scale_limit" {
   type        = number
   description = "Number of workers this function app can scale out to. Only applicable to apps on the Consumption and Premium plan."
-  default     = 1
+  default     = null
+  nullable    = true
 }

--- a/modules/azure/function_app_windows/variables.tf
+++ b/modules/azure/function_app_windows/variables.tf
@@ -111,3 +111,9 @@ variable "use_32_bit_worker" {
   description = "Should the Windows Function App use a 32-bit worker process."
   default     = true
 }
+
+variable "app_scale_limit" {
+  type        = number
+  description = "Number of workers this function app can scale out to. Only applicable to apps on the Consumption and Premium plan."
+  default     = 1
+}


### PR DESCRIPTION
- Its based on need to be able limit the scaling on demand and in some scenario limit the concurrency issues
- internal it does setting of functionAppScaleLimit which can be checked by following command as it is not visible anywhere within azure portal

az resource show --resource-type Microsoft.Web/sites -g <resource_group> -n <function_app>/config/web --query properties.functionAppScaleLimit