### PR TITLE
fix: resolve diagnostic settings inconsistent plan error in all modules

### DIFF
--- a/modules/azure/analysis_services/main.tf
+++ b/modules/azure/analysis_services/main.tf
@@ -33,11 +33,6 @@ resource "azurerm_analysis_services_server" "server" {
   }
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_analysis_services_server.server.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.name}"
@@ -47,28 +42,12 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   // TODO: not yet implemented by Azure
   // log_analytics_destination_type = "Dedicated"
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }

--- a/modules/azure/api_management/main.tf
+++ b/modules/azure/api_management/main.tf
@@ -120,11 +120,6 @@ resource "azurerm_api_management_diagnostic" "apim_diagnostic" {
   }
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_api_management.api_management.id
-}
-
 // Write logs and metrics to log analytics if specified
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
@@ -132,29 +127,13 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   target_resource_id         = azurerm_api_management.api_management.id
   log_analytics_workspace_id = var.log_analytics_workspace_id
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }
 

--- a/modules/azure/data_lake_storage/main.tf
+++ b/modules/azure/data_lake_storage/main.tf
@@ -118,11 +118,6 @@ resource "azurerm_storage_account_network_rules" "storage_account_network_rules"
   bypass                     = ["Logging", "Metrics", "AzureServices"]
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_storage_account.storage_account.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.name}"
@@ -132,28 +127,12 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   // TODO: not yet implemented by Azure
   // log_analytics_destination_type = "Dedicated"
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }

--- a/modules/azure/event_grid_topic/main.tf
+++ b/modules/azure/event_grid_topic/main.tf
@@ -23,11 +23,6 @@ resource "azurerm_eventgrid_system_topic" "topic" {
   topic_type             = var.topic_type
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.loganalytics_diagnostic_setting == null ? 0 : 1
-  resource_id = azurerm_eventgrid_system_topic.topic.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.loganalytics_diagnostic_setting == null ? 0 : 1
   name                       = "diag-${var.topic_name}"
@@ -35,20 +30,12 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   log_analytics_workspace_id = var.loganalytics_diagnostic_setting.workspace_id
 
 
-  dynamic "enabled_log" {
-    for_each = var.loganalytics_diagnostic_setting.categories == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types : var.loganalytics_diagnostic_setting.categories
-
-    content {
-      category = enabled_log.value
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = var.loganalytics_diagnostic_setting.metrics == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics : var.loganalytics_diagnostic_setting.metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }

--- a/modules/azure/event_hub/main.tf
+++ b/modules/azure/event_hub/main.tf
@@ -39,11 +39,6 @@ resource "azurerm_eventhub_consumer_group" "consumer" {
 }
 
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.loganalytics_diagnostic_setting == null ? 0 : 1
-  resource_id = azurerm_eventhub_namespace.namespace.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                          = var.loganalytics_diagnostic_setting == null ? 0 : 1
   name                           = "diag-${var.namespace_name}"
@@ -51,20 +46,12 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   log_analytics_workspace_id     = var.loganalytics_diagnostic_setting.workspace_id
   log_analytics_destination_type = var.loganalytics_diagnostic_setting.destination_type == null ? null : var.loganalytics_diagnostic_setting.destination_type
 
-  dynamic "enabled_log" {
-    for_each = var.loganalytics_diagnostic_setting.categories == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types : var.loganalytics_diagnostic_setting.categories
-
-    content {
-      category = enabled_log.value
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = var.loganalytics_diagnostic_setting.metrics == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics : var.loganalytics_diagnostic_setting.metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }

--- a/modules/azure/frontdoor_classic/main.tf
+++ b/modules/azure/frontdoor_classic/main.tf
@@ -141,11 +141,6 @@ resource "azurerm_frontdoor" "frontdoor" {
   }
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_frontdoor.frontdoor.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.name}"
@@ -155,29 +150,13 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   // TODO: not yet implemented by Azure
   // log_analytics_destination_type = "Dedicated"
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }
 

--- a/modules/azure/frontdoor_standard/main.tf
+++ b/modules/azure/frontdoor_standard/main.tf
@@ -172,34 +172,18 @@ resource "azurerm_cdn_frontdoor_security_policy" "fd_security_policy" {
 }
 
 # Diagnostic settings
-data "azurerm_monitor_diagnostic_categories" "fd_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_cdn_frontdoor_profile.fd_profile.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "fd_diagnostics" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.name}"
   target_resource_id         = azurerm_cdn_frontdoor_profile.fd_profile.id
   log_analytics_workspace_id = var.log_analytics_workspace_id
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.fd_categories[0].log_category_types
-    content {
-      category = enabled_log.value
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.fd_categories[0].metrics
-    content {
-      category = metric.value
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }

--- a/modules/azure/key_vault/main.tf
+++ b/modules/azure/key_vault/main.tf
@@ -82,11 +82,6 @@ resource "azurerm_key_vault" "key_vault" {
   }
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_key_vault.key_vault.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.name}"
@@ -96,28 +91,12 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   // TODO: not yet implemented by Azure
   // log_analytics_destination_type = "Dedicated"
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }

--- a/modules/azure/log_analytics_workspace/main.tf
+++ b/modules/azure/log_analytics_workspace/main.tf
@@ -26,11 +26,6 @@ resource "azurerm_log_analytics_workspace" "workspace" {
 
 
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.loganalytics_diagnostic_setting == null ? 0 : 1
-  resource_id = azurerm_log_analytics_workspace.workspace.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                          = var.loganalytics_diagnostic_setting == null ? 0 : 1
   name                           = "diag-${var.name}"
@@ -38,21 +33,13 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   log_analytics_workspace_id     = azurerm_log_analytics_workspace.workspace.id
   log_analytics_destination_type = var.loganalytics_diagnostic_setting.destination_type == null ? null : var.loganalytics_diagnostic_setting.destination_type
 
-  dynamic "enabled_log" {
-    for_each = var.loganalytics_diagnostic_setting.categories == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types : var.loganalytics_diagnostic_setting.categories
-
-    content {
-      category = enabled_log.value
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = var.loganalytics_diagnostic_setting.metrics == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics : var.loganalytics_diagnostic_setting.metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }
 

--- a/modules/azure/logic_app/main.tf
+++ b/modules/azure/logic_app/main.tf
@@ -69,11 +69,6 @@ resource "azurerm_resource_group_template_deployment" "workflow_deployment" {
   depends_on = [azurerm_logic_app_workflow.workflow]
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_logic_app_workflow.workflow.id
-}
-
 // Write logs and metrics to log analytics if specified
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
@@ -84,28 +79,12 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   // TODO: not yet implemented by Azure
   // log_analytics_destination_type = "Dedicated"
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }

--- a/modules/azure/logic_app_bicep/main.tf
+++ b/modules/azure/logic_app_bicep/main.tf
@@ -76,11 +76,6 @@ resource "azurerm_resource_group_template_deployment" "workflow_deployment" {
   depends_on = [azurerm_logic_app_workflow.workflow]
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_logic_app_workflow.workflow.id
-}
-
 // Write logs and metrics to log analytics if specified
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
@@ -91,29 +86,13 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   // TODO: not yet implemented by Azure
   // log_analytics_destination_type = "Dedicated"
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }
 

--- a/modules/azure/logic_app_set/main.tf
+++ b/modules/azure/logic_app_set/main.tf
@@ -50,11 +50,6 @@ resource "azurerm_resource_group_template_deployment" "workflow_deployment" {
   depends_on = [azurerm_logic_app_workflow.workflow]
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  for_each    = var.log_analytics_workspace_id == null ? {} : local.logic_app_instances
-  resource_id = azurerm_logic_app_workflow.workflow[each.key].id
-}
-
 // Write logs and metrics to log analytics if specified
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   for_each                   = var.log_analytics_workspace_id == null ? {} : local.logic_app_instances
@@ -65,28 +60,12 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   // TODO: not yet implemented by Azure
   // log_analytics_destination_type = "Dedicated"
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[each.key].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[each.key].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }

--- a/modules/azure/logic_app_standard/main.tf
+++ b/modules/azure/logic_app_standard/main.tf
@@ -143,11 +143,6 @@ resource "null_resource" "deploy" {
   }
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_logic_app_standard.app.id
-}
-
 // Write logs and metrics to log analytics if specified
 // Needs to be done once the deployment is finished, because updating Diagnostic Settings leads to a restart of the Logic App
 // which causes the deployment to fail if it is not finished yet
@@ -161,29 +156,13 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   target_resource_id         = azurerm_logic_app_standard.app.id
   log_analytics_workspace_id = var.log_analytics_workspace_id
 
-  dynamic "enabled_log" {
-    for_each = length(var.log_analytics_diagnostic_categories) > 0 ? var.log_analytics_diagnostic_categories : data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }
 

--- a/modules/azure/mssql/main.tf
+++ b/modules/azure/mssql/main.tf
@@ -92,11 +92,6 @@ resource "azurerm_private_endpoint" "private_endpoint" {
   }
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_mssql_database.mssql_database.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.database_name}"
@@ -106,28 +101,12 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   // TODO: not yet implemented by Azure
   // log_analytics_destination_type = "Dedicated"
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }

--- a/modules/azure/mysql/main.tf
+++ b/modules/azure/mysql/main.tf
@@ -78,11 +78,6 @@ resource "azurerm_private_endpoint" "private_endpoint" {
   }
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_mysql_server.mysql_server.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.mysql_server_name}"
@@ -92,29 +87,13 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   // TODO: not yet implemented by Azure
   // log_analytics_destination_type = "Dedicated"
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }
 

--- a/modules/azure/mysql_flexible_server/main.tf
+++ b/modules/azure/mysql_flexible_server/main.tf
@@ -68,40 +68,19 @@ resource "azurerm_mysql_flexible_server_configuration" "mysql_flexible_server_co
   value               = var.slow_query_log
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_mysql_flexible_server.mysql_flexible_server.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.mysql_server_name}"
   target_resource_id         = azurerm_mysql_flexible_server.mysql_flexible_server.id
   log_analytics_workspace_id = var.log_analytics_workspace_id
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 
   // TODO: not yet implemented by Azure

--- a/modules/azure/mysql_flexible_server_public/main.tf
+++ b/modules/azure/mysql_flexible_server_public/main.tf
@@ -66,40 +66,19 @@ resource "azurerm_mysql_flexible_server_configuration" "mysql_flexible_server_co
   value               = var.slow_query_log
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_mysql_flexible_server.mysql_flexible_server.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.server_name}"
   target_resource_id         = azurerm_mysql_flexible_server.mysql_flexible_server.id
   log_analytics_workspace_id = var.log_analytics_workspace_id
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 
   // TODO: not yet implemented by Azure

--- a/modules/azure/network_security_group/main.tf
+++ b/modules/azure/network_security_group/main.tf
@@ -48,11 +48,6 @@ resource "azurerm_subnet_network_security_group_association" "nsg_subnet_associa
 }
 
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.loganalytics_diagnostic_setting == null ? 0 : 1
-  resource_id = azurerm_network_security_group.network_security_group.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.loganalytics_diagnostic_setting == null ? 0 : 1
   name                       = "diag-${var.network_security_group_name}"
@@ -60,21 +55,13 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   log_analytics_workspace_id = var.loganalytics_diagnostic_setting.workspace_id
 
 
-  dynamic "enabled_log" {
-    for_each = var.loganalytics_diagnostic_setting.categories == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types : var.loganalytics_diagnostic_setting.categories
-
-    content {
-      category = enabled_log.value
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = var.loganalytics_diagnostic_setting.metrics == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics : var.loganalytics_diagnostic_setting.metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }
 

--- a/modules/azure/postgresql/main.tf
+++ b/modules/azure/postgresql/main.tf
@@ -78,11 +78,6 @@ resource "azurerm_postgresql_flexible_server_configuration" "configuration_query
   value     = "TOP"
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_postgresql_flexible_server.postgresql_server.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.name}"
@@ -92,28 +87,12 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   // TODO: not yet implemented by Azure
   // log_analytics_destination_type = "Dedicated"
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }

--- a/modules/azure/postgresql_public/main.tf
+++ b/modules/azure/postgresql_public/main.tf
@@ -75,11 +75,6 @@ resource "azurerm_postgresql_flexible_server_configuration" "configuration_query
   value     = "TOP"
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_postgresql_flexible_server.postgresql_server.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.name}"
@@ -89,29 +84,13 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   // TODO: not yet implemented by Azure
   // log_analytics_destination_type = "Dedicated"
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }
 

--- a/modules/azure/public_ip/main.tf
+++ b/modules/azure/public_ip/main.tf
@@ -24,11 +24,6 @@ resource "azurerm_public_ip" "public_ip" {
   sku                 = var.sku
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.loganalytics_diagnostic_setting == null ? 0 : 1
-  resource_id = azurerm_public_ip.public_ip.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.loganalytics_diagnostic_setting == null ? 0 : 1
   name                       = "diag-${var.name}"
@@ -36,21 +31,13 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   log_analytics_workspace_id = var.loganalytics_diagnostic_setting.workspace_id
 
 
-  dynamic "enabled_log" {
-    for_each = var.loganalytics_diagnostic_setting.categories == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types : var.loganalytics_diagnostic_setting.categories
-
-    content {
-      category = enabled_log.value
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = var.loganalytics_diagnostic_setting.metrics == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics : var.loganalytics_diagnostic_setting.metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }
 

--- a/modules/azure/service_bus_public/main.tf
+++ b/modules/azure/service_bus_public/main.tf
@@ -33,31 +33,18 @@ resource "azurerm_servicebus_namespace_authorization_rule" "authorization_rule" 
   manage = var.authorization_rule.manage
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_servicebus_namespace.service_bus.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.name}"
   target_resource_id         = azurerm_servicebus_namespace.service_bus.id
   log_analytics_workspace_id = var.log_analytics_workspace_id
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }

--- a/modules/azure/service_plan/main.tf
+++ b/modules/azure/service_plan/main.tf
@@ -86,11 +86,6 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_setting" {
 }
 
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.loganalytics_diagnostic_setting == null ? 0 : 1
-  resource_id = azurerm_service_plan.sp.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.loganalytics_diagnostic_setting == null ? 0 : 1
   name                       = "diag-${var.name}"
@@ -98,21 +93,13 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   log_analytics_workspace_id = var.loganalytics_diagnostic_setting.workspace_id
 
 
-  dynamic "enabled_log" {
-    for_each = var.loganalytics_diagnostic_setting.categories == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types : var.loganalytics_diagnostic_setting.categories
-
-    content {
-      category = enabled_log.value
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = var.loganalytics_diagnostic_setting.metrics == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics : var.loganalytics_diagnostic_setting.metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }
 

--- a/modules/azure/storage_account_public/main.tf
+++ b/modules/azure/storage_account_public/main.tf
@@ -118,47 +118,19 @@ resource "azurerm_storage_management_policy" "storage_management_policy" {
   }
 }
 
-data "azurerm_monitor_diagnostic_categories" "blob" {
-  count       = var.loganalytics_diagnostic_setting != null ? var.loganalytics_diagnostic_setting.workspace_id == null || var.loganalytics_diagnostic_setting.blob == null ? 0 : 1 : 0
-  resource_id = "${azurerm_storage_account.storage_account.id}/blobServices/default/"
-}
-
-data "azurerm_monitor_diagnostic_categories" "queue" {
-  count       = var.loganalytics_diagnostic_setting != null ? var.loganalytics_diagnostic_setting.workspace_id == null || var.loganalytics_diagnostic_setting.queue == null ? 0 : 1 : 0
-  resource_id = "${azurerm_storage_account.storage_account.id}/queueServices/default/"
-}
-
-data "azurerm_monitor_diagnostic_categories" "table" {
-  count       = var.loganalytics_diagnostic_setting != null ? var.loganalytics_diagnostic_setting.workspace_id == null || var.loganalytics_diagnostic_setting.table == null ? 0 : 1 : 0
-  resource_id = "${azurerm_storage_account.storage_account.id}/tableServices/default/"
-}
-
-data "azurerm_monitor_diagnostic_categories" "file" {
-  count       = var.loganalytics_diagnostic_setting != null ? var.loganalytics_diagnostic_setting.workspace_id == null || var.loganalytics_diagnostic_setting.file == null ? 0 : 1 : 0
-  resource_id = "${azurerm_storage_account.storage_account.id}/fileServices/default/"
-}
-
 resource "azurerm_monitor_diagnostic_setting" "blob" {
   count                      = var.loganalytics_diagnostic_setting != null ? var.loganalytics_diagnostic_setting.workspace_id == null || var.loganalytics_diagnostic_setting.blob == null ? 0 : 1 : 0
   name                       = "diag-blob-${var.name}"
   target_resource_id         = "${azurerm_storage_account.storage_account.id}/blobServices/default/"
   log_analytics_workspace_id = var.loganalytics_diagnostic_setting.workspace_id
 
-  dynamic "enabled_log" {
-    for_each = var.loganalytics_diagnostic_setting.blob.categories == null ? data.azurerm_monitor_diagnostic_categories.blob[0].log_category_types : var.loganalytics_diagnostic_setting.blob.categories
-
-    content {
-      category = enabled_log.value
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = var.loganalytics_diagnostic_setting.blob.metrics == null ? data.azurerm_monitor_diagnostic_categories.blob[0].metrics : var.loganalytics_diagnostic_setting.blob.metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }
 
@@ -168,21 +140,13 @@ resource "azurerm_monitor_diagnostic_setting" "queue" {
   target_resource_id         = "${azurerm_storage_account.storage_account.id}/queueServices/default/"
   log_analytics_workspace_id = var.loganalytics_diagnostic_setting.workspace_id
 
-  dynamic "enabled_log" {
-    for_each = var.loganalytics_diagnostic_setting.queue.categories == null ? data.azurerm_monitor_diagnostic_categories.queue[0].log_category_types : var.loganalytics_diagnostic_setting.queue.categories
-
-    content {
-      category = enabled_log.value
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = var.loganalytics_diagnostic_setting.queue.metrics == null ? data.azurerm_monitor_diagnostic_categories.queue[0].metrics : var.loganalytics_diagnostic_setting.queue.metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }
 
@@ -192,21 +156,13 @@ resource "azurerm_monitor_diagnostic_setting" "table" {
   target_resource_id         = "${azurerm_storage_account.storage_account.id}/tableServices/default/"
   log_analytics_workspace_id = var.loganalytics_diagnostic_setting.workspace_id
 
-  dynamic "enabled_log" {
-    for_each = var.loganalytics_diagnostic_setting.table.categories == null ? data.azurerm_monitor_diagnostic_categories.table[0].log_category_types : var.loganalytics_diagnostic_setting.table.categories
-
-    content {
-      category = enabled_log.value
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = var.loganalytics_diagnostic_setting.table.metrics == null ? data.azurerm_monitor_diagnostic_categories.table[0].metrics : var.loganalytics_diagnostic_setting.table.metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }
 
@@ -216,20 +172,12 @@ resource "azurerm_monitor_diagnostic_setting" "file" {
   target_resource_id         = "${azurerm_storage_account.storage_account.id}/fileServices/default/"
   log_analytics_workspace_id = var.loganalytics_diagnostic_setting.workspace_id
 
-  dynamic "enabled_log" {
-    for_each = var.loganalytics_diagnostic_setting.file.categories == null ? data.azurerm_monitor_diagnostic_categories.file[0].log_category_types : var.loganalytics_diagnostic_setting.file.categories
-
-    content {
-      category = enabled_log.value
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = var.loganalytics_diagnostic_setting.file.metrics == null ? data.azurerm_monitor_diagnostic_categories.file[0].metrics : var.loganalytics_diagnostic_setting.file.metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }

--- a/modules/azure/stream_analytics/main.tf
+++ b/modules/azure/stream_analytics/main.tf
@@ -102,11 +102,6 @@ resource "azurerm_stream_analytics_output_blob" "stream_output" {
 }
 
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.loganalytics_diagnostic_setting == null ? 0 : 1
-  resource_id = azurerm_stream_analytics_job.job.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.loganalytics_diagnostic_setting == null ? 0 : 1
   name                       = "diag-${var.name}"
@@ -114,20 +109,12 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   log_analytics_workspace_id = var.loganalytics_diagnostic_setting.workspace_id
 
 
-  dynamic "enabled_log" {
-    for_each = var.loganalytics_diagnostic_setting.categories == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types : var.loganalytics_diagnostic_setting.categories
-
-    content {
-      category = enabled_log.value
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = var.loganalytics_diagnostic_setting.metrics == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics : var.loganalytics_diagnostic_setting.metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }

--- a/modules/azure/synapse_workspace/main.tf
+++ b/modules/azure/synapse_workspace/main.tf
@@ -103,40 +103,19 @@ resource "azurerm_synapse_workspace" "workspace" {
   }
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_synapse_workspace.workspace.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.workspace_name}"
   target_resource_id         = azurerm_synapse_workspace.workspace.id
   log_analytics_workspace_id = var.log_analytics_workspace_id
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }
 

--- a/modules/azure/virtual_network/main.tf
+++ b/modules/azure/virtual_network/main.tf
@@ -28,11 +28,6 @@ resource "azurerm_virtual_network" "virtual_network" {
 }
 
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.loganalytics_diagnostic_setting == null ? 0 : 1
-  resource_id = azurerm_virtual_network.virtual_network.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.loganalytics_diagnostic_setting == null ? 0 : 1
   name                       = "diag-${var.name}"
@@ -40,20 +35,12 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   log_analytics_workspace_id = var.loganalytics_diagnostic_setting.workspace_id
 
 
-  dynamic "enabled_log" {
-    for_each = var.loganalytics_diagnostic_setting.categories == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types : var.loganalytics_diagnostic_setting.categories
-
-    content {
-      category = enabled_log.value
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = var.loganalytics_diagnostic_setting.metrics == null ? data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics : var.loganalytics_diagnostic_setting.metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }

--- a/modules/azure/web_app_linux/main.tf
+++ b/modules/azure/web_app_linux/main.tf
@@ -125,11 +125,6 @@ resource "azurerm_app_service_certificate_binding" "custom_hostname_certificate_
   ssl_state           = "SniEnabled"
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_linux_web_app.web_app.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.name}"
@@ -139,28 +134,12 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   // TODO: not yet implemented by Azure
   // log_analytics_destination_type = "Dedicated"
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }

--- a/modules/azure/web_app_windows/main.tf
+++ b/modules/azure/web_app_windows/main.tf
@@ -114,11 +114,6 @@ resource "azurerm_app_service_custom_hostname_binding" "custom_domain" {
   resource_group_name = var.resource_group_name
 }
 
-data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {
-  count       = var.log_analytics_workspace_id == null ? 0 : 1
-  resource_id = azurerm_windows_web_app.web_app.id
-}
-
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   count                      = var.log_analytics_workspace_id == null ? 0 : 1
   name                       = "diag-${var.name}"
@@ -128,28 +123,12 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   // TODO: not yet implemented by Azure
   // log_analytics_destination_type = "Dedicated"
 
-  dynamic "enabled_log" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].log_category_types
-
-    content {
-      category = enabled_log.value
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  enabled_log {
+    category_group = "allLogs"
   }
 
-  dynamic "metric" {
-    for_each = data.azurerm_monitor_diagnostic_categories.diagnostic_categories[0].metrics
-
-    content {
-      category = metric.value
-      enabled  = true
-
-      retention_policy {
-        enabled = false
-      }
-    }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
   }
 }


### PR DESCRIPTION
## Summary
Follow-up to #454. Fix the same "Provider produced inconsistent final plan" error in **all 29 remaining modules**.

## Problem
Same root cause as #454: `data.azurerm_monitor_diagnostic_categories` returns different categories after a resource is modified, causing Terraform plan/apply mismatch.

This was blocking service_tickets deployments on ACC due to `logic_app_standard` modules.

## Changes
- Remove all `data "azurerm_monitor_diagnostic_categories"` data sources
- Replace all `dynamic "enabled_log"` blocks with `category_group = "allLogs"` 
- Replace all `dynamic "metric"` blocks with `category = "AllMetrics"`
- 29 modules fixed, -723 lines removed

## Test plan
- [ ] Verify service_tickets deployment succeeds on ACC