### PR TITLE
Entra ID-only storage support (AB#7496)

### DIFF
--- a/modules/azure/storage_account_public/main.tf
+++ b/modules/azure/storage_account_public/main.tf
@@ -28,6 +28,7 @@ resource "azurerm_storage_account" "storage_account" {
   nfsv3_enabled                   = var.nfsv3_enabled
   is_hns_enabled                  = var.is_hns_enabled
   sftp_enabled                    = var.sftp_enabled
+  shared_access_key_enabled       = var.shared_access_key_enabled
 
   blob_properties {
     dynamic "cors_rule" {

--- a/modules/azure/storage_account_public/main.tf
+++ b/modules/azure/storage_account_public/main.tf
@@ -13,6 +13,10 @@ terraform {
 
 provider "azurerm" {
   features {}
+
+  # Use Entra ID (Azure AD) for the Storage data plane instead of Shared Key.
+  # Required when the target storage account has shared_access_key_enabled = false.
+  storage_use_azuread = var.storage_use_azuread
 }
 
 resource "azurerm_storage_account" "storage_account" {

--- a/modules/azure/storage_account_public/variables.tf
+++ b/modules/azure/storage_account_public/variables.tf
@@ -149,3 +149,9 @@ variable "sftp_enabled" {
   default     = false
 }
 
+variable "shared_access_key_enabled" {
+  type        = bool
+  description = "Whether the storage account permits requests to be authorized with the account access key (Shared Key). Set to false to enforce Entra ID (Azure AD) authorization only."
+  default     = true
+}
+

--- a/modules/azure/storage_account_public/variables.tf
+++ b/modules/azure/storage_account_public/variables.tf
@@ -155,3 +155,9 @@ variable "shared_access_key_enabled" {
   default     = true
 }
 
+variable "storage_use_azuread" {
+  type        = bool
+  description = "Authenticate Storage data-plane operations (blob/queue properties) with Entra ID (Azure AD) instead of the account access key. Set to true when shared key access is disabled on the account."
+  default     = false
+}
+

--- a/modules/azure/storage_blob/main.tf
+++ b/modules/azure/storage_blob/main.tf
@@ -13,6 +13,10 @@ terraform {
 
 provider "azurerm" {
   features {}
+
+  # Use Entra ID (Azure AD) for the Storage data plane instead of Shared Key.
+  # Required when the target storage account has shared_access_key_enabled = false.
+  storage_use_azuread = var.storage_use_azuread
 }
 
 resource "azurerm_storage_blob" "storage_blob" {

--- a/modules/azure/storage_blob/outputs.tf
+++ b/modules/azure/storage_blob/outputs.tf
@@ -2,3 +2,10 @@ output "storage_blob_url" {
   value     = "https://${azurerm_storage_blob.storage_blob.storage_account_name}.blob.core.windows.net/${azurerm_storage_blob.storage_blob.storage_container_name}/${azurerm_storage_blob.storage_blob.name}${data.azurerm_storage_account_sas.sas_token.sas}"
   sensitive = true
 }
+
+# Plain blob URL without SAS. Use together with a managed identity that has
+# (at least) Storage Blob Data Reader on the account, e.g. for identity-based
+# WEBSITE_RUN_FROM_PACKAGE when shared key access is disabled on the account.
+output "storage_blob_url_without_sas" {
+  value = "https://${azurerm_storage_blob.storage_blob.storage_account_name}.blob.core.windows.net/${azurerm_storage_blob.storage_blob.storage_container_name}/${azurerm_storage_blob.storage_blob.name}"
+}

--- a/modules/azure/storage_blob/variables.tf
+++ b/modules/azure/storage_blob/variables.tf
@@ -30,3 +30,9 @@ variable "local_source" {
   default     = null
 }
 
+variable "storage_use_azuread" {
+  type        = bool
+  description = "Authenticate Storage data-plane operations (blob upload/read) with Entra ID (Azure AD) instead of the account access key. Set to true when shared key access is disabled on the account."
+  default     = false
+}
+

--- a/modules/azure/storage_container/main.tf
+++ b/modules/azure/storage_container/main.tf
@@ -13,6 +13,10 @@ terraform {
 
 provider "azurerm" {
   features {}
+
+  # Use Entra ID (Azure AD) for the Storage data plane instead of Shared Key.
+  # Required when the target storage account has shared_access_key_enabled = false.
+  storage_use_azuread = var.storage_use_azuread
 }
 
 resource "azurerm_storage_container" "storage_container" {

--- a/modules/azure/storage_container/variables.tf
+++ b/modules/azure/storage_container/variables.tf
@@ -13,3 +13,9 @@ variable "storage_container_access_type" {
   description = "Access type of the storage account."
   default     = "private"
 }
+
+variable "storage_use_azuread" {
+  type        = bool
+  description = "Authenticate Storage data-plane operations (container create/read) with Entra ID (Azure AD) instead of the account access key. Set to true when shared key access is disabled on the account."
+  default     = false
+}

--- a/modules/azure/storage_table_azapi/main.tf
+++ b/modules/azure/storage_table_azapi/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = "~> 1.12"
+
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 1.15"
+    }
+  }
+
+  backend "azurerm" {}
+}
+
+provider "azapi" {}
+
+# Entra ID (Azure AD) native equivalent of the azurerm_storage_table module.
+# Manages the table via the ARM control plane (Microsoft.Storage), so it does
+# NOT require Shared Key / data-plane access and keeps working when the storage
+# account has shared_access_key_enabled = false.
+resource "azapi_resource" "storage_table" {
+  type      = "Microsoft.Storage/storageAccounts/tableServices/tables@2023-01-01"
+  name      = var.storage_table_name
+  parent_id = "${var.storage_account_id}/tableServices/default"
+  body      = jsonencode({})
+}

--- a/modules/azure/storage_table_azapi/outputs.tf
+++ b/modules/azure/storage_table_azapi/outputs.tf
@@ -1,0 +1,7 @@
+output "name" {
+  value = azapi_resource.storage_table.name
+}
+
+output "id" {
+  value = azapi_resource.storage_table.id
+}

--- a/modules/azure/storage_table_azapi/variables.tf
+++ b/modules/azure/storage_table_azapi/variables.tf
@@ -1,0 +1,9 @@
+variable "storage_account_id" {
+  type        = string
+  description = "Resource ID of the storage account that hosts the table (e.g. azurerm_storage_account.x.id)."
+}
+
+variable "storage_table_name" {
+  type        = string
+  description = "Name of the storage table."
+}


### PR DESCRIPTION
Adds opt-in support for disabling Storage shared key access, used by the kpn-tickets Defender remediation (AB#7496). All changes are additive and backward-compatible (defaults preserve current behaviour).

- `storage_account_public`: `shared_access_key_enabled` (default true) + `storage_use_azuread` (default false)
- `storage_blob`: `storage_use_azuread` + `storage_blob_url_without_sas` output (identity-based run-from-package)
- `storage_container`: `storage_use_azuread`
- new `storage_table_azapi` module (manages tables via ARM control plane, works with shared key disabled)

Released as tag v3.16.33 and validated end-to-end on the Telecom kpn-tickets dev+tst environments with shared key access disabled.